### PR TITLE
Adding useSystemProperties to HttpClient setup

### DIFF
--- a/geoportal-application/geoportal-harvester-cli/src/main/java/com/esri/geoportal/cli/boot/Bootstrap.java
+++ b/geoportal-application/geoportal-harvester-cli/src/main/java/com/esri/geoportal/cli/boot/Bootstrap.java
@@ -263,7 +263,7 @@ public class Bootstrap {
       inboundConnectorRegistry.put(WafConnector.TYPE, new WafConnector());
       inboundConnectorRegistry.put(UncConnector.TYPE, new UncConnector());
       inboundConnectorRegistry.put(AgpInputConnector.TYPE, new AgpInputConnector(metaBuilder));
-      inboundConnectorRegistry.put(AgsConnector.TYPE, new AgsConnector(metaBuilder, new GeometryService(HttpClients.custom().build(), new URL(geometryServiceUrl))));
+      inboundConnectorRegistry.put(AgsConnector.TYPE, new AgsConnector(metaBuilder, new GeometryService(HttpClients.custom().useSystemProperties().build(), new URL(geometryServiceUrl))));
       inboundConnectorRegistry.put(GptConnector.TYPE, new GptConnector());
       inboundConnectorRegistry.put(CkanConnector.TYPE, new CkanConnector(metaBuilder));
       inboundConnectorRegistry.put(DataGovConnector.TYPE, new DataGovConnector(metaBuilder));

--- a/geoportal-application/geoportal-harvester-war/src/main/java/com/esri/geoportal/harvester/beans/GeometryServiceBean.java
+++ b/geoportal-application/geoportal-harvester-war/src/main/java/com/esri/geoportal/harvester/beans/GeometryServiceBean.java
@@ -31,7 +31,7 @@ public class GeometryServiceBean extends GeometryService {
    * @throws MalformedURLException if invalid geometry service url
    */
   public GeometryServiceBean(String geometryServiceUrl) throws MalformedURLException {
-    super(HttpClients.custom().build(), new URL(geometryServiceUrl));
+    super(HttpClients.custom().useSystemProperties().build(), new URL(geometryServiceUrl));
   }
   
 }

--- a/geoportal-commons/geoportal-commons-gpt-client/src/main/java/com/esri/geoportal/commons/gpt/client/Client.java
+++ b/geoportal-commons/geoportal-commons-gpt-client/src/main/java/com/esri/geoportal/commons/gpt/client/Client.java
@@ -110,7 +110,7 @@ public class Client implements Closeable {
    * @param index index name
    */
   public Client(URL url, SimpleCredentials cred, String index) {
-    this(HttpClientBuilder.create().build(), url, cred, index);
+    this(HttpClientBuilder.create().useSystemProperties().build(), url, cred, index);
   }
 
   /**

--- a/geoportal-commons/geoportal-commons-robots/src/main/java/com/esri/geoportal/commons/http/BotsHttpClient.java
+++ b/geoportal-commons/geoportal-commons-robots/src/main/java/com/esri/geoportal/commons/http/BotsHttpClient.java
@@ -54,7 +54,7 @@ public class BotsHttpClient extends CloseableHttpClient {
   }
 
   public BotsHttpClient(Bots bots) {
-    this.client = HttpClientBuilder.create().build();
+    this.client = HttpClientBuilder.create().useSystemProperties().build();
     this.bots = bots;
   }
 

--- a/geoportal-commons/geoportal-commons-robots/src/main/java/com/esri/geoportal/commons/robots/BotsUtils.java
+++ b/geoportal-commons/geoportal-commons-robots/src/main/java/com/esri/geoportal/commons/robots/BotsUtils.java
@@ -32,7 +32,7 @@ public final class BotsUtils {
    * @return default parser (never <code>null</code>)
    */
   public static BotsParser parser() {
-    return parser(BotsConfig.DEFAULT,HttpClientBuilder.create().build());
+    return parser(BotsConfig.DEFAULT,HttpClientBuilder.create().useSystemProperties().build());
   }
   
   /**

--- a/geoportal-connectors/geoportal-harvester-agp-publisher/src/main/java/com/esri/geoportal/harvester/agp/AgpOutputBroker.java
+++ b/geoportal-connectors/geoportal-harvester-agp-publisher/src/main/java/com/esri/geoportal/harvester/agp/AgpOutputBroker.java
@@ -354,7 +354,7 @@ import org.xml.sax.SAXException;
   @Override
   public void initialize(InitContext context) throws DataProcessorException {
     definition.override(context.getParams());
-    this.client = new AgpClient(HttpClientBuilder.create().build(), definition.getHostUrl(),definition.getCredentials());
+    this.client = new AgpClient(HttpClientBuilder.create().useSystemProperties().build(), definition.getHostUrl(),definition.getCredentials());
     if(definition.getCleanup()) {
       context.addListener(new BaseProcessInstanceListener() {
         @Override

--- a/geoportal-connectors/geoportal-harvester-agp-source/src/main/java/com/esri/geoportal/harvester/agpsrc/AgpInputBroker.java
+++ b/geoportal-connectors/geoportal-harvester-agp-source/src/main/java/com/esri/geoportal/harvester/agpsrc/AgpInputBroker.java
@@ -127,7 +127,7 @@ import com.esri.geoportal.commons.utils.XmlUtils;
   @Override
   public void initialize(InitContext context) throws DataProcessorException {
     definition.override(context.getParams());
-    CloseableHttpClient httpclient = HttpClientBuilder.create().build();
+    CloseableHttpClient httpclient = HttpClientBuilder.create().useSystemProperties().build();
     if (context.getTask().getTaskDefinition().isIgnoreRobotsTxt()) {
       client = new AgpClient(httpclient, definition.getHostUrl(),definition.getCredentials());
     } else {

--- a/geoportal-connectors/geoportal-harvester-ags/src/main/java/com/esri/geoportal/harvester/ags/AgsBroker.java
+++ b/geoportal-connectors/geoportal-harvester-ags/src/main/java/com/esri/geoportal/harvester/ags/AgsBroker.java
@@ -101,7 +101,7 @@ import com.esri.geoportal.geoportal.commons.geometry.GeometryService;
   @Override
   public void initialize(InitContext context) throws DataProcessorException {
     definition.override(context.getParams());
-    CloseableHttpClient httpclient = HttpClientBuilder.create().build();
+    CloseableHttpClient httpclient = HttpClientBuilder.create().useSystemProperties().build();
     if (context.getTask().getTaskDefinition().isIgnoreRobotsTxt()) {
       client = new AgsClient(httpclient, definition.getHostUrl());
     } else {

--- a/geoportal-connectors/geoportal-harvester-ckan/src/main/java/com/esri/geoportal/harvester/ckan/CkanBroker.java
+++ b/geoportal-connectors/geoportal-harvester-ckan/src/main/java/com/esri/geoportal/harvester/ckan/CkanBroker.java
@@ -105,7 +105,7 @@ public class CkanBroker implements InputBroker {
   @Override
   public void initialize(InitContext context) throws DataProcessorException {
     definition.override(context.getParams());
-    CloseableHttpClient http = HttpClientBuilder.create().build();
+    CloseableHttpClient http = HttpClientBuilder.create().useSystemProperties().build();
     if (context.getTask().getTaskDefinition().isIgnoreRobotsTxt()) {
       httpClient = http;
     } else {

--- a/geoportal-connectors/geoportal-harvester-csw/src/main/java/com/esri/geoportal/harvester/csw/CswBroker.java
+++ b/geoportal-connectors/geoportal-harvester-csw/src/main/java/com/esri/geoportal/harvester/csw/CswBroker.java
@@ -67,7 +67,7 @@ import org.slf4j.LoggerFactory;
   @Override
   public void initialize(InitContext context) throws DataProcessorException {
     definition.override(context.getParams());
-    httpclient = HttpClientBuilder.create().build();
+    httpclient = HttpClientBuilder.create().useSystemProperties().build();
     if (context.getTask().getTaskDefinition().isIgnoreRobotsTxt()) {
       client = new Client(httpclient, definition.getHostUrl(), definition.getProfile(), definition.getCredentials());
     } else {

--- a/geoportal-connectors/geoportal-harvester-gptsrc/src/main/java/com/esri/geoportal/harvester/gptsrc/GptBroker.java
+++ b/geoportal-connectors/geoportal-harvester-gptsrc/src/main/java/com/esri/geoportal/harvester/gptsrc/GptBroker.java
@@ -57,7 +57,7 @@ class GptBroker implements InputBroker {
   @Override
   public void initialize(InitContext context) throws DataProcessorException {
     definition.override(context.getParams());
-    CloseableHttpClient httpClient = HttpClientBuilder.create().build();
+    CloseableHttpClient httpClient = HttpClientBuilder.create().useSystemProperties().build();
     if (context.getTask().getTaskDefinition().isIgnoreRobotsTxt()) {
       client = new Client(httpClient, definition.getHostUrl(), definition.getCredentials(), definition.getIndex());
     } else {

--- a/geoportal-connectors/geoportal-harvester-waf/src/main/java/com/esri/geoportal/harvester/waf/WafBroker.java
+++ b/geoportal-connectors/geoportal-harvester-waf/src/main/java/com/esri/geoportal/harvester/waf/WafBroker.java
@@ -64,7 +64,7 @@ import org.slf4j.LoggerFactory;
   @Override
   public void initialize(InitContext context) throws DataProcessorException {
     definition.override(context.getParams());
-    CloseableHttpClient client = HttpClientBuilder.create().build();
+    CloseableHttpClient client = HttpClientBuilder.create().useSystemProperties().build();
     if (context.getTask().getTaskDefinition().isIgnoreRobotsTxt()) {
       httpClient = client;
     } else {


### PR DESCRIPTION
This change is necessary so that the geoportal-harvester can accept different keystores and truststores at run time. The full list of system properties (according to the [Apache documentation](http://hc.apache.org/httpcomponents-client-ga/httpclient/apidocs/org/apache/http/impl/client/HttpClientBuilder.html)) is:

- ssl.TrustManagerFactory.algorithm
- javax.net.ssl.trustStoreType
- javax.net.ssl.trustStore
- javax.net.ssl.trustStoreProvider
- javax.net.ssl.trustStorePassword
- ssl.KeyManagerFactory.algorithm
- javax.net.ssl.keyStoreType
- javax.net.ssl.keyStore
- javax.net.ssl.keyStoreProvider
- javax.net.ssl.keyStorePassword
- https.protocols
- https.cipherSuites
- http.proxyHost
- http.proxyPort
- https.proxyHost
- https.proxyPort
- http.nonProxyHosts
- http.keepAlive
- http.maxConnections
- http.agent