### PR TITLE
Push WAF files to AGP

### DIFF
--- a/geoportal-commons/geoportal-commons-constants/src/main/java/com/esri/geoportal/commons/constants/ItemType.java
+++ b/geoportal-commons/geoportal-commons-constants/src/main/java/com/esri/geoportal/commons/constants/ItemType.java
@@ -110,7 +110,8 @@ public enum ItemType {
   CODE_SAMPLE("Code Sample", File),
   DESKTOP_ADD_IN("Desktop Add In", File, MimeType.APPLICATION_ESRI_ADDIN),
   EXPLORER_ADD_IN("Explorer Add In", File, MimeType.APPLICATION_ESRI_EAZ),
-  ARCGIS_PRO_ADD_IN("ArcGIS Pro Add In", File, MimeType.APPLICATION_ESRI_ADDINX);
+  ARCGIS_PRO_ADD_IN("ArcGIS Pro Add In", File, MimeType.APPLICATION_ESRI_ADDINX),
+  METADATA_XML("Document Link", URL, Pattern.compile(".+\\.xml$", Pattern.CASE_INSENSITIVE), "", MimeType.APPLICATION_XML);
 
   private final String typeName;
   private final DataType dataType;

--- a/geoportal-connectors/geoportal-harvester-agp-publisher/src/main/java/com/esri/geoportal/harvester/agp/AgpOutputBroker.java
+++ b/geoportal-connectors/geoportal-harvester-agp-publisher/src/main/java/com/esri/geoportal/harvester/agp/AgpOutputBroker.java
@@ -56,8 +56,6 @@ import java.util.stream.Collectors;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
-
-import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.apache.http.impl.client.HttpClientBuilder;
@@ -106,9 +104,6 @@ import org.xml.sax.SAXException;
         throw new DataOutputException(this, String.format("Error extracting attributes from data."));
       }
 
-      System.out.println("Attributes: " + attributes.toString());
-      System.out.println("Ref map attributes " + ref.getAttributesMap().toString());
-
       // build typeKeywords array
       String src_source_type_s = URLEncoder.encode(ref.getBrokerUri().getScheme(), "UTF-8");
       String src_source_uri_s = URLEncoder.encode(ref.getBrokerUri().toASCIIString(), "UTF-8");
@@ -126,28 +121,23 @@ import org.xml.sax.SAXException;
       
       try {
 
-        System.out.println("Getting token...");
         // generate token
         if (token == null) {
           token = generateToken();
         }
-        System.out.println("...got token");
-
        
-        // String urlStr = getAttributeValue(attributes, WKAConstants.WKA_RESOURCE_URL, null);
-        // System.out.println("WKA_RESOURCE_URL: " + Hex.encodeHexString(urlStr.getBytes()));
-        // if (urlStr == null || urlStr.trim() == "") {
-        String urlStr = ((URI)ref.getAttributesMap().get(WKAConstants.WKA_RESOURCE_URL)).toString();
-        // }
+        String urlStr = getAttributeValue(attributes, WKAConstants.WKA_RESOURCE_URL, null);
 
-        // find resource URL
+        // If the WKA_RESOURCE_URL is empty after parsing the XML file, see if it was set on the 
+        // DataReference directly.
+        if (urlStr == null || urlStr.isEmpty()) {
+          urlStr = ((URI)ref.getAttributesMap().get(WKAConstants.WKA_RESOURCE_URL)).toString();
+        }
+
         URL resourceUrl = new URL(urlStr);
-
-        System.out.println("resourceUrl: " + resourceUrl.toExternalForm());
 
         ItemType itemType = ItemType.matchPattern(resourceUrl.toExternalForm()).stream().findFirst().orElse(null);
         if (itemType == null || itemType.getDataType()!=DataType.URL) {
-          System.err.println(String.format("Skipping file %s. Data Type: %s", resourceUrl.toExternalForm(), itemType != null ? itemType.getDataType() : "null ItemType"));
           return PublishingStatus.SKIPPED;
         }
         

--- a/geoportal-connectors/geoportal-harvester-waf/src/main/java/com/esri/geoportal/harvester/waf/WafFile.java
+++ b/geoportal-connectors/geoportal-harvester-waf/src/main/java/com/esri/geoportal/harvester/waf/WafFile.java
@@ -18,12 +18,15 @@ package com.esri.geoportal.harvester.waf;
 import com.esri.geoportal.commons.constants.HttpConstants;
 import com.esri.geoportal.commons.constants.MimeType;
 import com.esri.geoportal.commons.constants.MimeTypeUtils;
+import com.esri.geoportal.commons.meta.util.WKAConstants;
+
 import static com.esri.geoportal.commons.utils.Constants.DEFAULT_REQUEST_CONFIG;
 import static com.esri.geoportal.commons.utils.HttpClientContextBuilder.createHttpClientContext;
 import com.esri.geoportal.commons.utils.SimpleCredentials;
 import com.esri.geoportal.harvester.api.base.SimpleDataReference;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.time.ZonedDateTime;
@@ -83,6 +86,10 @@ import org.apache.http.impl.client.CloseableHttpClient;
       boolean readBody = since==null || lastModifiedDate==null || lastModifiedDate.getTime()>=since.getTime();
       SimpleDataReference ref = new SimpleDataReference(broker.getBrokerUri(), broker.getEntityDefinition().getLabel(), fileUrl.toExternalForm(), lastModifiedDate, fileUrl.toURI(), broker.td.getSource().getRef(), broker.td.getRef());
       ref.addContext(contentType, readBody? IOUtils.toByteArray(input): null);
+
+      // Adding in resource map attributes for saving to AGP...
+      ref.getAttributesMap().put(WKAConstants.WKA_RESOURCE_URL, fileUrl.toURI());
+
       return ref;
     }
   }


### PR DESCRIPTION
This set of changes allows for web accessible folder (WAF) files to be pushed to Portal for ArcGIS (AGP) as Document Links