### PR TITLE
Handle redirections from AGP

### DIFF
--- a/geoportal-application/geoportal-harvester-war/src/main/webapp/hrv/ui/main/UIRenderer.js
+++ b/geoportal-application/geoportal-harvester-war/src/main/webapp/hrv/ui/main/UIRenderer.js
@@ -28,13 +28,14 @@ define(["dojo/_base/declare",
         "dijit/form/CheckBox",
         "dijit/form/TimeTextBox",
         "dijit/form/RadioButton",
+        "dijit/form/NumberTextBox",
         "dijit/form/Form",
         "dojox/html/entities",
         "hrv/utils/TextScrambler"
       ],
   function(declare,i18n,
            lang,array,domConstruct,domAttr,html,number,
-           Select,ValidationTextBox,CheckBox,TimeTextBox,RadioButton,Form,
+           Select,ValidationTextBox,CheckBox,TimeTextBox,RadioButton,NumberTextBox,Form,
            entities,TextScrambler
           ){
   
@@ -75,6 +76,7 @@ define(["dojo/_base/declare",
           case "bool": return this.renderBool(placeholderNode,arg);
           case "temporal": return this.renderTime(placeholderNode,arg);
           case "periodical": return this.renderPeriod(placeholderNode,arg);
+          case "integer": return this.renderInteger(placeholderNode, arg);
           default: 
             console.error("Unsupported argument type:", arg.type);
             return {
@@ -110,6 +112,29 @@ define(["dojo/_base/declare",
             input.destroy();
           } 
         };
+      },
+
+      renderInteger: function (placeholderNode, arg) {
+        var input = new NumberTextBox({
+          name: arg.name,
+          required: arg.required
+        }).placeAt(placeholderNode);
+
+        input.set("value", arg.defaultValue ? Number(arg.defaultValue) : 0);
+
+        input.startup();
+
+        return {
+          init: function (values) {
+            input.set("value", Number(values[arg.name]));
+          },
+          read: function (values) {
+            values[arg.name] = input.get("value");
+          },
+          destroy: function () {
+            input.destroy();
+          }
+        }
       },
       
       renderChoice: function(placeholderNode,arg) {

--- a/geoportal-commons/geoportal-commons-agp-client/src/main/java/com/esri/geoportal/commons/agp/client/AgpClient.java
+++ b/geoportal-commons/geoportal-commons-agp-client/src/main/java/com/esri/geoportal/commons/agp/client/AgpClient.java
@@ -61,6 +61,7 @@ public class AgpClient implements Closeable {
   private final URL rootUrl;
   private final SimpleCredentials credentials;
   private final CloseableHttpClient httpClient;
+  private final Integer maxRedirects;
   
   /**
    * Creates instance of the client.
@@ -69,9 +70,14 @@ public class AgpClient implements Closeable {
    * @param credentials credentials
    */
   public AgpClient(CloseableHttpClient httpClient, URL rootUrl, SimpleCredentials credentials) {
+    this(httpClient, rootUrl, credentials, DEFAULT_MAX_REDIRECTS);
+  }
+
+  public AgpClient(CloseableHttpClient httpClient, URL rootUrl, SimpleCredentials credentials, Integer maxRedirects) {
     this.rootUrl = adjustUrl(rootUrl);
     this.credentials = credentials;
     this.httpClient = httpClient;
+    this.maxRedirects = maxRedirects;
   }
 
   @Override
@@ -573,7 +579,7 @@ public class AgpClient implements Closeable {
   
   private String execute(HttpUriRequest req, Integer redirectDepth) throws IOException {
     // Determine if we've reached the limit of redirection attempts
-    if (redirectDepth > DEFAULT_MAX_REDIRECTS) {
+    if (redirectDepth > this.maxRedirects) {
       throw new HttpResponseException(HttpStatus.SC_GONE, "Too many redirects, aborting");
     }
 

--- a/geoportal-connectors/geoportal-harvester-agp-publisher/src/main/java/com/esri/geoportal/harvester/agp/AgpConstants.java
+++ b/geoportal-connectors/geoportal-harvester-agp-publisher/src/main/java/com/esri/geoportal/harvester/agp/AgpConstants.java
@@ -22,4 +22,5 @@ package com.esri.geoportal.harvester.agp;
   public static final String P_HOST_URL    = "agp-host-url";
   public static final String P_FOLDER_ID   = "agp-folder-id";
   public static final String P_FOLDER_CLEANUP = "agp-folder-cleanup";
+  public static final String P_MAX_REDIRECTS = "agp-max-redirects";
 }

--- a/geoportal-connectors/geoportal-harvester-agp-publisher/src/main/java/com/esri/geoportal/harvester/agp/AgpOutputBroker.java
+++ b/geoportal-connectors/geoportal-harvester-agp-publisher/src/main/java/com/esri/geoportal/harvester/agp/AgpOutputBroker.java
@@ -363,7 +363,7 @@ import org.xml.sax.SAXException;
   @Override
   public void initialize(InitContext context) throws DataProcessorException {
     definition.override(context.getParams());
-    this.client = new AgpClient(HttpClientBuilder.create().useSystemProperties().build(), definition.getHostUrl(),definition.getCredentials());
+    this.client = new AgpClient(HttpClientBuilder.create().useSystemProperties().build(), definition.getHostUrl(),definition.getCredentials(), definition.getMaxRedirects());
     if(definition.getCleanup()) {
       context.addListener(new BaseProcessInstanceListener() {
         @Override

--- a/geoportal-connectors/geoportal-harvester-agp-publisher/src/main/java/com/esri/geoportal/harvester/agp/AgpOutputBrokerDefinitionAdaptor.java
+++ b/geoportal-connectors/geoportal-harvester-agp-publisher/src/main/java/com/esri/geoportal/harvester/agp/AgpOutputBrokerDefinitionAdaptor.java
@@ -25,17 +25,20 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Map;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.math.NumberUtils;
 
 /**
  * ArcGIS Portal definition adaptor.
  */
 /*package*/ class AgpOutputBrokerDefinitionAdaptor  extends BrokerDefinitionAdaptor {
+  private static final Integer DEFAULT_MAX_REDIRECTS = 5;
 
   private final CredentialsDefinitionAdaptor credAdaptor;
   
   private URL hostUrl;
   private String folderId;
   private boolean cleanup;
+  private Integer maxRedirects;
 
   /**
    * Creates instance of the adaptor.
@@ -57,6 +60,7 @@ import org.apache.commons.lang3.StringUtils;
       }
       folderId = get(P_FOLDER_ID);
       cleanup  = Boolean.parseBoolean(get(P_FOLDER_CLEANUP));
+      maxRedirects = NumberUtils.toInt(get(P_MAX_REDIRECTS), DEFAULT_MAX_REDIRECTS);
     }
   }
 
@@ -65,6 +69,7 @@ import org.apache.commons.lang3.StringUtils;
     consume(params,P_HOST_URL);
     consume(params,P_FOLDER_ID);
     consume(params,P_FOLDER_CLEANUP);
+    consume(params, P_MAX_REDIRECTS);
     credAdaptor.override(params);
   }
   
@@ -134,6 +139,20 @@ import org.apache.commons.lang3.StringUtils;
     this.cleanup = cleanup;
     set(P_FOLDER_CLEANUP, Boolean.toString(cleanup));
   }
+
+/**
+ * @return the maxRedirects
+ */
+public Integer getMaxRedirects() {
+	return maxRedirects;
+}
+
+/**
+ * @param maxRedirects the maxRedirects to set
+ */
+public void setMaxRedirects(Integer maxRedirects) {
+	this.maxRedirects = maxRedirects;
+}
   
   
 }

--- a/geoportal-connectors/geoportal-harvester-agp-publisher/src/main/java/com/esri/geoportal/harvester/agp/AgpOutputConnector.java
+++ b/geoportal-connectors/geoportal-harvester-agp-publisher/src/main/java/com/esri/geoportal/harvester/agp/AgpOutputConnector.java
@@ -71,6 +71,7 @@ public class AgpOutputConnector implements OutputConnector<OutputBroker> {
         return true;
       }
     });
+    args.add(new UITemplate.IntegerArgument(P_MAX_REDIRECTS, bundle.getString("agp.max.redirects"), false, 5));
     args.add(new UITemplate.BooleanArgument(P_FOLDER_CLEANUP, "Perform cleanup"));
     return new UITemplate(getType(), bundle.getString("agp"), args);
   }

--- a/geoportal-connectors/geoportal-harvester-agp-publisher/src/main/resources/AgpResource.properties
+++ b/geoportal-connectors/geoportal-harvester-agp-publisher/src/main/resources/AgpResource.properties
@@ -18,4 +18,5 @@ agp.folderId = Folder
 agp.username = User name
 agp.password = user password
 agp.cleanup = Perform cleanup
+agp.max.redirects = Maximum redirects
 agp.hint = http://www.arcgis.com

--- a/geoportal-connectors/geoportal-harvester-agp-source/src/main/java/com/esri/geoportal/harvester/agpsrc/AgpConstants.java
+++ b/geoportal-connectors/geoportal-harvester-agp-source/src/main/java/com/esri/geoportal/harvester/agpsrc/AgpConstants.java
@@ -24,4 +24,5 @@ package com.esri.geoportal.harvester.agpsrc;
   public static final String P_EMIT_XML    = "agp-emit-xml";
   public static final String P_EMIT_XML_FMT= "agp-emit-xml-fmt";
   public static final String P_EMIT_JSON   = "agp-emit-json";
+  public static final String P_MAX_REDIRECTS = "agp-max-redirects";
 }

--- a/geoportal-connectors/geoportal-harvester-agp-source/src/main/java/com/esri/geoportal/harvester/agpsrc/AgpInputBroker.java
+++ b/geoportal-connectors/geoportal-harvester-agp-source/src/main/java/com/esri/geoportal/harvester/agpsrc/AgpInputBroker.java
@@ -132,10 +132,10 @@ import com.esri.geoportal.harvester.api.defs.TaskDefinition;
     td = context.getTask().getTaskDefinition();
     CloseableHttpClient httpclient = HttpClientBuilder.create().useSystemProperties().build();
     if (context.getTask().getTaskDefinition().isIgnoreRobotsTxt()) {
-      client = new AgpClient(httpclient, definition.getHostUrl(),definition.getCredentials());
+      client = new AgpClient(httpclient, definition.getHostUrl(),definition.getCredentials(), definition.getMaxRedirects());
     } else {
       Bots bots = BotsUtils.readBots(definition.getBotsConfig(), httpclient, definition.getHostUrl());
-      client = new AgpClient(new BotsHttpClient(httpclient,bots), definition.getHostUrl(), definition.getCredentials());
+      client = new AgpClient(new BotsHttpClient(httpclient,bots), definition.getHostUrl(), definition.getCredentials(), definition.getMaxRedirects());
     }
     
     try {

--- a/geoportal-connectors/geoportal-harvester-agp-source/src/main/java/com/esri/geoportal/harvester/agpsrc/AgpInputBrokerDefinitionAdaptor.java
+++ b/geoportal-connectors/geoportal-harvester-agp-source/src/main/java/com/esri/geoportal/harvester/agpsrc/AgpInputBrokerDefinitionAdaptor.java
@@ -29,11 +29,14 @@ import java.net.URL;
 import java.util.Map;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.math.NumberUtils;
 
 /**
  * ArcGIS Portal definition adaptor.
  */
 /*package*/ class AgpInputBrokerDefinitionAdaptor  extends BrokerDefinitionAdaptor {
+
+  private static final Integer DEFAULT_MAX_REDIRECTS = 5;
 
   private final BotsBrokerDefinitionAdaptor botsAdaptor;
   private final CredentialsDefinitionAdaptor credAdaptor;
@@ -43,6 +46,7 @@ import org.apache.commons.lang3.StringUtils;
   private boolean emitXml = true;
   private boolean emitJson = false;
   private MetadataFormat metaFormat = MetadataFormat.DEFAULT;
+  private Integer maxRedirects;
 
   /**
    * Creates instance of the adaptor.
@@ -67,6 +71,7 @@ import org.apache.commons.lang3.StringUtils;
       emitXml = BooleanUtils.toBooleanDefaultIfNull(BooleanUtils.toBooleanObject(get(P_EMIT_XML)), true);
       emitJson = BooleanUtils.toBooleanDefaultIfNull(BooleanUtils.toBooleanObject(get(P_EMIT_JSON)), false);
       metaFormat = MetadataFormat.parse(get(P_EMIT_XML_FMT), MetadataFormat.DEFAULT);
+      maxRedirects = NumberUtils.toInt(get(P_MAX_REDIRECTS), DEFAULT_MAX_REDIRECTS);
     }
   }
 
@@ -77,6 +82,7 @@ import org.apache.commons.lang3.StringUtils;
     consume(params,P_EMIT_XML);
     consume(params,P_EMIT_JSON);
     consume(params,P_EMIT_XML_FMT);
+    consume(params, P_MAX_REDIRECTS);
     credAdaptor.override(params);
     botsAdaptor.override(params);
   }
@@ -172,6 +178,20 @@ import org.apache.commons.lang3.StringUtils;
   public void setMetaFormat(MetadataFormat metaFormat) {
     this.metaFormat = metaFormat;
     set(P_EMIT_XML_FMT, (metaFormat != null ? metaFormat : MetadataFormat.DEFAULT).toString());
+  }
+
+  /**
+   * @return the maxRedirects
+   */
+  public Integer getMaxRedirects() {
+    return maxRedirects;
+  }
+
+  /**
+   * @param maxRedirects the maxRedirects to set
+   */
+  public void setMaxRedirects(Integer maxRedirects) {
+    this.maxRedirects = maxRedirects;
   }
   
 }

--- a/geoportal-connectors/geoportal-harvester-agp-source/src/main/java/com/esri/geoportal/harvester/agpsrc/AgpInputConnector.java
+++ b/geoportal-connectors/geoportal-harvester-agp-source/src/main/java/com/esri/geoportal/harvester/agpsrc/AgpInputConnector.java
@@ -84,6 +84,9 @@ public class AgpInputConnector implements InputConnector<InputBroker> {
     });
     
     args.add(new UITemplate.BooleanArgument(P_EMIT_JSON, bundle.getString("agpsrc.emit.json"),false, Boolean.FALSE));
+
+    args.add(new UITemplate.IntegerArgument(P_MAX_REDIRECTS, bundle.getString("agpsrc.max.redirects"), false, 5));
+
     return new UITemplate(getType(), bundle.getString("agpsrc"), args);
   }
   

--- a/geoportal-connectors/geoportal-harvester-agp-source/src/main/resources/AgpSrcResource.properties
+++ b/geoportal-connectors/geoportal-harvester-agp-source/src/main/resources/AgpSrcResource.properties
@@ -20,6 +20,7 @@ agpsrc.password = User password
 agpsrc.hint = http://www.arcgis.com
 agpsrc.emit.xml = Emit XML
 agpsrc.emit.json = Emit JSON
+agpsrc.max.redirects = Maximum redirects
 agpsrc.format = Preferred metadata format
 agpsrc.format.default = Default
 agpsrc.format.iso19115 = ISO 19115


### PR DESCRIPTION
This update handles the case where a redirect is received when accessing an ArcGIS Enterprise Portal. Normally, the Apache HTTP client will handle this, but there are certain situations where we have to explicitly handle the redirect request.