### PR TITLE
Fixing query in AGP Client

### DIFF
--- a/geoportal-commons/geoportal-commons-agp-client/src/main/java/com/esri/geoportal/commons/agp/client/AgpClient.java
+++ b/geoportal-commons/geoportal-commons-agp-client/src/main/java/com/esri/geoportal/commons/agp/client/AgpClient.java
@@ -409,7 +409,7 @@ public class AgpClient implements Closeable {
     builder.setParameter("num", Long.toString(num));
     builder.setParameter("start", Long.toString(start));
     
-    String type = Arrays.stream(Config.readTypes()).map(s->StringUtils.trimToNull(s)).filter(s->s != null).collect(Collectors.joining(" OR "));
+    String type = Arrays.stream(Config.readTypes()).map(s->StringUtils.trimToNull(s)).filter(s->s != null).collect(Collectors.joining(") OR type: ("));
     String q = String.format("type: (%s)", type);
     builder.setParameter("q", q);
     


### PR DESCRIPTION
Needed to separate out the "type" options into separate search terms, otherwise the query only returns portal items that start with "Feature"