### PR TITLE
File Upload to ArcGIS Portal

### DIFF
--- a/geoportal-commons/geoportal-commons-agp-client/src/main/java/com/esri/geoportal/commons/agp/client/AgpClient.java
+++ b/geoportal-commons/geoportal-commons-agp-client/src/main/java/com/esri/geoportal/commons/agp/client/AgpClient.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.Closeable;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
@@ -97,12 +98,13 @@ public class AgpClient implements Closeable {
    * @param extent extent
    * @param typeKeywords type keywords
    * @param tags tags tags
+   * @param fileToUpload the file to be uploaded
    * @param token token
    * @return add item response
    * @throws URISyntaxException if invalid URL
    * @throws IOException if operation fails
    */
-  public ItemResponse addItem(String owner, String folderId, String title, String description, URL url, URL thumbnailUrl, ItemType itemType, Double [] extent, String [] typeKeywords, String [] tags, String token) throws IOException, URISyntaxException {
+  public ItemResponse addItem(String owner, String folderId, String title, String description, URL url, URL thumbnailUrl, ItemType itemType, Double [] extent, String [] typeKeywords, String [] tags, File fileToUpload, String token) throws IOException, URISyntaxException {
     URIBuilder builder = new URIBuilder(addItemUri(owner, StringUtils.trimToNull(folderId)));
     
     HttpPost req = new HttpPost(builder.build());
@@ -128,12 +130,13 @@ public class AgpClient implements Closeable {
    * @param extent extent
    * @param typeKeywords type keywords
    * @param tags tags tags
+   * @param fileToUpload the file to be uploaded
    * @param token token
    * @return add item response
    * @throws URISyntaxException if invalid URL
    * @throws IOException if operation fails
    */
-  public ItemResponse updateItem(String owner, String folderId, String itemId, String title, String description, URL url, URL thumbnailUrl, ItemType itemType, Double [] extent, String [] typeKeywords, String [] tags, String token) throws IOException, URISyntaxException {
+  public ItemResponse updateItem(String owner, String folderId, String itemId, String title, String description, URL url, URL thumbnailUrl, ItemType itemType, Double [] extent, String [] typeKeywords, String [] tags, File fileToUpload, String token) throws IOException, URISyntaxException {
     URIBuilder builder = new URIBuilder(updateItemUri(owner, StringUtils.trimToNull(folderId), itemId));
     
     HttpPost req = new HttpPost(builder.build());

--- a/geoportal-commons/geoportal-commons-agp-client/src/main/java/com/esri/geoportal/commons/agp/client/AgpClient.java
+++ b/geoportal-commons/geoportal-commons-agp-client/src/main/java/com/esri/geoportal/commons/agp/client/AgpClient.java
@@ -87,52 +87,6 @@ public class AgpClient implements Closeable {
 
   /**
    * Adds item.
-   * @param owner owner
-   * @param folderId folder id (optional)
-   * @param title title
-   * @param description description
-   * @param text text
-   * @param thumbnailUrl thumbnail url
-   * @param itemType item type (must be a URL type)
-   * @param extent extent
-   * @param typeKeywords type keywords
-   * @param tags tags tags
-   * @param token token
-   * @return add item response
-   * @throws URISyntaxException if invalid URL
-   * @throws IOException if operation fails
-   */
-  public ItemResponse addItem(String owner, String folderId, String title, String description, String text, URL thumbnailUrl, ItemType itemType, Double [] extent, String [] typeKeywords, String [] tags, String token) throws IOException, URISyntaxException {
-    URIBuilder builder = new URIBuilder(addItemUri(owner, StringUtils.trimToNull(folderId)));
-    
-    HttpPost req = new HttpPost(builder.build());
-    HashMap<String, String> params = new HashMap<>();
-    params.put("f", "json");
-    params.put("title", title);
-    params.put("description", description);
-    params.put("type", itemType.getTypeName());
-    params.put("text", text);
-    if (thumbnailUrl!=null) {
-      params.put("thumbnailurl", thumbnailUrl.toExternalForm());
-    }
-    if (extent!=null && extent.length==4) {
-      params.put("extent",Arrays.asList(extent).stream().map(Object::toString).collect(Collectors.joining(",")));
-    }
-    if (typeKeywords!=null) {
-      params.put("typeKeywords", Arrays.asList(typeKeywords).stream().collect(Collectors.joining(",")));
-    }
-    if (tags!=null) {
-      params.put("tags", Arrays.asList(tags).stream().collect(Collectors.joining(",")));
-    }
-    params.put("token", token);
-    
-    req.setEntity(createEntity(params));
-
-    return execute(req,ItemResponse.class);
-  }
-
-  /**
-   * Adds item.
    * @param owner user name
    * @param folderId folder id (optional)
    * @param title title
@@ -152,25 +106,70 @@ public class AgpClient implements Closeable {
     URIBuilder builder = new URIBuilder(addItemUri(owner, StringUtils.trimToNull(folderId)));
     
     HttpPost req = new HttpPost(builder.build());
-    HashMap<String, String> params = new HashMap<>();
-    params.put("f", "json");
-    params.put("title", title);
-    params.put("description", description);
-    params.put("type", itemType.getTypeName());
+    
+    Map<String, String> params = makeStdParams(title, description, itemType, thumbnailUrl, extent, typeKeywords, tags, token);
     params.put("url", url.toExternalForm());
-    if (thumbnailUrl!=null) {
-      params.put("thumbnailurl", thumbnailUrl.toExternalForm());
-    }
-    if (extent!=null && extent.length==4) {
-      params.put("extent",Arrays.asList(extent).stream().map(Object::toString).collect(Collectors.joining(",")));
-    }
-    if (typeKeywords!=null) {
-      params.put("typeKeywords", Arrays.asList(typeKeywords).stream().collect(Collectors.joining(",")));
-    }
-    if (tags!=null) {
-      params.put("tags", Arrays.asList(tags).stream().collect(Collectors.joining(",")));
-    }
-    params.put("token", token);
+    
+    req.setEntity(createEntity(params));
+
+    return execute(req,ItemResponse.class);
+  }
+  
+  /**
+   * Adds item.
+   * @param owner user name
+   * @param folderId folder id (optional)
+   * @param itemId item id
+   * @param title title
+   * @param description description
+   * @param url URL
+   * @param thumbnailUrl thumbnail URL
+   * @param itemType item type (must be a URL type)
+   * @param extent extent
+   * @param typeKeywords type keywords
+   * @param tags tags tags
+   * @param token token
+   * @return add item response
+   * @throws URISyntaxException if invalid URL
+   * @throws IOException if operation fails
+   */
+  public ItemResponse updateItem(String owner, String folderId, String itemId, String title, String description, URL url, URL thumbnailUrl, ItemType itemType, Double [] extent, String [] typeKeywords, String [] tags, String token) throws IOException, URISyntaxException {
+    URIBuilder builder = new URIBuilder(updateItemUri(owner, StringUtils.trimToNull(folderId), itemId));
+    
+    HttpPost req = new HttpPost(builder.build());
+    
+    Map<String, String> params = makeStdParams(title, description, itemType, thumbnailUrl, extent, typeKeywords, tags, token);
+    params.put("url", url.toExternalForm());
+    
+    req.setEntity(createEntity(params));
+
+    return execute(req,ItemResponse.class);
+  }
+
+  /**
+   * Adds item.
+   * @param owner owner
+   * @param folderId folder id (optional)
+   * @param title title
+   * @param description description
+   * @param text text
+   * @param thumbnailUrl thumbnail url
+   * @param itemType item type (must be a URL type)
+   * @param extent extent
+   * @param typeKeywords type keywords
+   * @param tags tags tags
+   * @param token token
+   * @return add item response
+   * @throws URISyntaxException if invalid URL
+   * @throws IOException if operation fails
+   */
+  public ItemResponse addItem(String owner, String folderId, String title, String description, String text, URL thumbnailUrl, ItemType itemType, Double [] extent, String [] typeKeywords, String [] tags, String token) throws IOException, URISyntaxException {
+    URIBuilder builder = new URIBuilder(addItemUri(owner, StringUtils.trimToNull(folderId)));
+    
+    HttpPost req = new HttpPost(builder.build());
+    
+    Map<String, String> params = makeStdParams(title, description, itemType, thumbnailUrl, extent, typeKeywords, tags, token);
+    params.put("text", text);
     
     req.setEntity(createEntity(params));
 
@@ -199,12 +198,21 @@ public class AgpClient implements Closeable {
     URIBuilder builder = new URIBuilder(updateItemUri(owner, StringUtils.trimToNull(folderId), itemId));
     
     HttpPost req = new HttpPost(builder.build());
+    
+    Map<String, String> params = makeStdParams(title, description, itemType, thumbnailUrl, extent, typeKeywords, tags, token);
+    params.put("text", text);
+    
+    req.setEntity(createEntity(params));
+
+    return execute(req,ItemResponse.class);
+  }
+  
+  private Map<String, String> makeStdParams(String title, String description, ItemType itemType, URL thumbnailUrl, Double [] extent, String [] typeKeywords, String [] tags, String token) {
     HashMap<String, String> params = new HashMap<>();
     params.put("f", "json");
     params.put("title", title);
     params.put("description", description);
     params.put("type", itemType.getTypeName());
-    params.put("text", text);
     if (thumbnailUrl!=null) {
       params.put("thumbnailurl", thumbnailUrl.toExternalForm());
     }
@@ -219,9 +227,7 @@ public class AgpClient implements Closeable {
     }
     params.put("token", token);
     
-    req.setEntity(createEntity(params));
-
-    return execute(req,ItemResponse.class);
+    return params;
   }
 
   /**
@@ -270,53 +276,6 @@ public class AgpClient implements Closeable {
       }
       throw ex;
     }
-  }
-  
-  /**
-   * Adds item.
-   * @param owner user name
-   * @param folderId folder id (optional)
-   * @param itemId item id
-   * @param title title
-   * @param description description
-   * @param url URL
-   * @param thumbnailUrl thumbnail URL
-   * @param itemType item type (must be a URL type)
-   * @param extent extent
-   * @param typeKeywords type keywords
-   * @param tags tags tags
-   * @param token token
-   * @return add item response
-   * @throws URISyntaxException if invalid URL
-   * @throws IOException if operation fails
-   */
-  public ItemResponse updateItem(String owner, String folderId, String itemId, String title, String description, URL url, URL thumbnailUrl, ItemType itemType, Double [] extent, String [] typeKeywords, String [] tags, String token) throws IOException, URISyntaxException {
-    URIBuilder builder = new URIBuilder(updateItemUri(owner, StringUtils.trimToNull(folderId), itemId));
-    
-    HttpPost req = new HttpPost(builder.build());
-    HashMap<String, String> params = new HashMap<>();
-    params.put("f", "json");
-    params.put("title", title);
-    params.put("description", description);
-    params.put("type", itemType.getTypeName());
-    params.put("url", url.toExternalForm());
-    if (thumbnailUrl!=null) {
-      params.put("thumbnailurl", thumbnailUrl.toExternalForm());
-    }
-    if (extent!=null && extent.length==4) {
-      params.put("extent",Arrays.asList(extent).stream().map(Object::toString).collect(Collectors.joining(",")));
-    }
-    if (typeKeywords!=null) {
-      params.put("typeKeywords", Arrays.asList(typeKeywords).stream().collect(Collectors.joining(",")));
-    }
-    if (tags!=null) {
-      params.put("tags", Arrays.asList(tags).stream().collect(Collectors.joining(",")));
-    }
-    params.put("token", token);
-    
-    req.setEntity(createEntity(params));
-
-    return execute(req,ItemResponse.class);
   }
   
   /**

--- a/geoportal-commons/geoportal-commons-agp-client/src/main/java/com/esri/geoportal/commons/agp/client/AgpClient.java
+++ b/geoportal-commons/geoportal-commons-agp-client/src/main/java/com/esri/geoportal/commons/agp/client/AgpClient.java
@@ -119,7 +119,7 @@ public class AgpClient implements Closeable {
     
     Map<String, String> params = makeStdParams(title, description, itemType, thumbnailUrl, extent, typeKeywords, tags, token);
     if (!multipart) {
-      params.put(itemType.getDataType().name().toLowerCase(), url.toExternalForm());
+      params.put("url", url.toExternalForm());
     }
     
     req.setEntity(multipart? createEntity(params, fileToUpload): createEntity(params));
@@ -154,7 +154,7 @@ public class AgpClient implements Closeable {
     
     Map<String, String> params = makeStdParams(title, description, itemType, thumbnailUrl, extent, typeKeywords, tags, token);
     if (!multipart) {
-      params.put(itemType.getDataType().name().toLowerCase(), url.toExternalForm());
+      params.put("url", url.toExternalForm());
     }
     
     req.setEntity(multipart? createEntity(params, fileToUpload): createEntity(params));

--- a/geoportal-commons/geoportal-commons-agp-client/src/main/java/com/esri/geoportal/commons/agp/client/AgpClient.java
+++ b/geoportal-commons/geoportal-commons-agp-client/src/main/java/com/esri/geoportal/commons/agp/client/AgpClient.java
@@ -49,13 +49,20 @@ import org.apache.http.client.methods.HttpRequestWrapper;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.client.utils.URIUtils;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.mime.HttpMultipartMode;
+import org.apache.http.entity.mime.MultipartEntityBuilder;
+import org.apache.http.entity.mime.content.StringBody;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.message.BasicNameValuePair;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * ArcGIS Portal client.
  */
 public class AgpClient implements Closeable {
+  private static final Logger LOG = LoggerFactory.getLogger(AgpClient.class);
   private static final String QUERY_EXTRAS = "-type:\"Layer\" -type: \"Map Document\" -type:\"Map Package\" -type:\"Basemap Package\" -type:\"Mobile Basemap Package\" -type:\"Mobile Map Package\" -type:\"ArcPad Package\" -type:\"Project Package\" -type:\"Project Template\" -type:\"Desktop Style\" -type:\"Pro Map\" -type:\"Layout\" -type:\"Explorer Map\" -type:\"Globe Document\" -type:\"Scene Document\" -type:\"Published Map\" -type:\"Map Template\" -type:\"Windows Mobile Package\" -type:\"Layer Package\" -type:\"Explorer Layer\" -type:\"Geoprocessing Package\" -type:\"Desktop Application Template\" -type:\"Code Sample\" -type:\"Geoprocessing Package\" -type:\"Geoprocessing Sample\" -type:\"Locator Package\" -type:\"Workflow Manager Package\" -type:\"Windows Mobile Package\" -type:\"Explorer Add In\" -type:\"Desktop Add In\" -type:\"File Geodatabase\" -type:\"Feature Collection Template\" -type:\"Code Attachment\" -type:\"Featured Items\" -type:\"Symbol Set\" -type:\"Color Set\" -type:\"Windows Viewer Add In\" -type:\"Windows Viewer Configuration\"";
   private static final Integer DEFAULT_MAX_REDIRECTS = 5;
   
@@ -105,14 +112,17 @@ public class AgpClient implements Closeable {
    * @throws IOException if operation fails
    */
   public ItemResponse addItem(String owner, String folderId, String title, String description, URL url, URL thumbnailUrl, ItemType itemType, Double [] extent, String [] typeKeywords, String [] tags, File fileToUpload, String token) throws IOException, URISyntaxException {
+    boolean multipart = fileToUpload!=null;
     URIBuilder builder = new URIBuilder(addItemUri(owner, StringUtils.trimToNull(folderId)));
     
     HttpPost req = new HttpPost(builder.build());
     
     Map<String, String> params = makeStdParams(title, description, itemType, thumbnailUrl, extent, typeKeywords, tags, token);
-    params.put(itemType.getDataType().name().toLowerCase(), url.toExternalForm());
+    if (!multipart) {
+      params.put(itemType.getDataType().name().toLowerCase(), url.toExternalForm());
+    }
     
-    req.setEntity(createEntity(params));
+    req.setEntity(multipart? createEntity(params, fileToUpload): createEntity(params));
 
     return execute(req,ItemResponse.class);
   }
@@ -137,14 +147,17 @@ public class AgpClient implements Closeable {
    * @throws IOException if operation fails
    */
   public ItemResponse updateItem(String owner, String folderId, String itemId, String title, String description, URL url, URL thumbnailUrl, ItemType itemType, Double [] extent, String [] typeKeywords, String [] tags, File fileToUpload, String token) throws IOException, URISyntaxException {
+    boolean multipart = fileToUpload!=null;
     URIBuilder builder = new URIBuilder(updateItemUri(owner, StringUtils.trimToNull(folderId), itemId));
     
     HttpPost req = new HttpPost(builder.build());
     
     Map<String, String> params = makeStdParams(title, description, itemType, thumbnailUrl, extent, typeKeywords, tags, token);
-    params.put(itemType.getDataType().name().toLowerCase(), url.toExternalForm());
+    if (!multipart) {
+      params.put(itemType.getDataType().name().toLowerCase(), url.toExternalForm());
+    }
     
-    req.setEntity(createEntity(params));
+    req.setEntity(multipart? createEntity(params, fileToUpload): createEntity(params));
 
     return execute(req,ItemResponse.class);
   }
@@ -165,7 +178,9 @@ public class AgpClient implements Closeable {
    * @return add item response
    * @throws URISyntaxException if invalid URL
    * @throws IOException if operation fails
+   * @deprecated to be removed without substitution
    */
+  @Deprecated
   public ItemResponse addItem(String owner, String folderId, String title, String description, String text, URL thumbnailUrl, ItemType itemType, Double [] extent, String [] typeKeywords, String [] tags, String token) throws IOException, URISyntaxException {
     URIBuilder builder = new URIBuilder(addItemUri(owner, StringUtils.trimToNull(folderId)));
     
@@ -196,7 +211,9 @@ public class AgpClient implements Closeable {
    * @return add item response
    * @throws URISyntaxException if invalid URL
    * @throws IOException if operation fails
+   * @deprecated to be removed without substitution
    */
+  @Deprecated
   public ItemResponse updateItem(String owner, String folderId, String itemId, String title, String description, String text, URL thumbnailUrl, ItemType itemType, Double [] extent, String [] typeKeywords, String [] tags, String token) throws IOException, URISyntaxException {
     URIBuilder builder = new URIBuilder(updateItemUri(owner, StringUtils.trimToNull(folderId), itemId));
     
@@ -208,29 +225,6 @@ public class AgpClient implements Closeable {
     req.setEntity(createEntity(params));
 
     return execute(req,ItemResponse.class);
-  }
-  
-  private Map<String, String> makeStdParams(String title, String description, ItemType itemType, URL thumbnailUrl, Double [] extent, String [] typeKeywords, String [] tags, String token) {
-    HashMap<String, String> params = new HashMap<>();
-    params.put("f", "json");
-    params.put("title", title);
-    params.put("description", description);
-    params.put("type", itemType.getTypeName());
-    if (thumbnailUrl!=null) {
-      params.put("thumbnailurl", thumbnailUrl.toExternalForm());
-    }
-    if (extent!=null && extent.length==4) {
-      params.put("extent",Arrays.asList(extent).stream().map(Object::toString).collect(Collectors.joining(",")));
-    }
-    if (typeKeywords!=null) {
-      params.put("typeKeywords", Arrays.asList(typeKeywords).stream().collect(Collectors.joining(",")));
-    }
-    if (tags!=null) {
-      params.put("tags", Arrays.asList(tags).stream().collect(Collectors.joining(",")));
-    }
-    params.put("token", token);
-    
-    return params;
   }
 
   /**
@@ -449,6 +443,29 @@ public class AgpClient implements Closeable {
     return execute(req,TokenResponse.class);
   }
   
+  private Map<String, String> makeStdParams(String title, String description, ItemType itemType, URL thumbnailUrl, Double [] extent, String [] typeKeywords, String [] tags, String token) {
+    HashMap<String, String> params = new HashMap<>();
+    params.put("f", "json");
+    params.put("title", title);
+    params.put("description", description);
+    params.put("type", itemType.getTypeName());
+    if (thumbnailUrl!=null) {
+      params.put("thumbnailurl", thumbnailUrl.toExternalForm());
+    }
+    if (extent!=null && extent.length==4) {
+      params.put("extent",Arrays.asList(extent).stream().map(Object::toString).collect(Collectors.joining(",")));
+    }
+    if (typeKeywords!=null) {
+      params.put("typeKeywords", Arrays.asList(typeKeywords).stream().collect(Collectors.joining(",")));
+    }
+    if (tags!=null) {
+      params.put("tags", Arrays.asList(tags).stream().collect(Collectors.joining(",")));
+    }
+    params.put("token", token);
+    
+    return params;
+  }
+  
   private URI itemInfoUri(String itemId) throws URISyntaxException {
     URIBuilder builder = new URIBuilder();
     builder.setScheme(rootUrl.toURI().getScheme())
@@ -475,7 +492,7 @@ public class AgpClient implements Closeable {
            .setPath(rootUrl.toURI().getPath() + "sharing/rest/content/users/" + owner + (folderId!=null? "/" +folderId: "") +"/items/" + itemId + "/update");
     return builder.build();
   }
-
+  
   private URI addItemUri(String owner, String folderId) throws URISyntaxException {
     URIBuilder builder = new URIBuilder();
     builder.setScheme(rootUrl.toURI().getScheme())
@@ -531,6 +548,14 @@ public class AgpClient implements Closeable {
             .map(e -> new BasicNameValuePair(e.getKey(), e.getValue())).collect(Collectors.toList()), "UTF-8");
   }
   
+  private HttpEntity createEntity(Map<String, String> params, File file) throws UnsupportedEncodingException {
+    MultipartEntityBuilder builder = MultipartEntityBuilder.create();
+    builder.setMode(HttpMultipartMode.RFC6532);
+    params.entrySet().stream().forEach(e->builder.addPart(e.getKey(), new StringBody(e.getValue(), ContentType.MULTIPART_FORM_DATA)));
+    builder.addBinaryBody("file", file);
+    return builder.build();
+  }
+  
   private <T> T execute(HttpUriRequest req, Class<T> clazz) throws IOException {
     String responseContent = execute(req, 0);
     ObjectMapper mapper = new ObjectMapper();
@@ -573,8 +598,8 @@ public class AgpClient implements Closeable {
             newReq.setURI(redirUrl);
 
             return execute(newReq, ++redirectDepth);
-          } catch (Exception e) {
-            e.printStackTrace();
+          } catch (IOException | URISyntaxException e) {
+            LOG.debug("Error executing request", e);
             throw new HttpResponseException(httpResponse.getStatusLine().getStatusCode(), httpResponse.getStatusLine().getReasonPhrase());
           }
         }

--- a/geoportal-commons/geoportal-commons-agp-client/src/main/java/com/esri/geoportal/commons/agp/client/AgpClient.java
+++ b/geoportal-commons/geoportal-commons-agp-client/src/main/java/com/esri/geoportal/commons/agp/client/AgpClient.java
@@ -108,7 +108,7 @@ public class AgpClient implements Closeable {
     HttpPost req = new HttpPost(builder.build());
     
     Map<String, String> params = makeStdParams(title, description, itemType, thumbnailUrl, extent, typeKeywords, tags, token);
-    params.put("url", url.toExternalForm());
+    params.put(itemType.getDataType().name().toLowerCase(), url.toExternalForm());
     
     req.setEntity(createEntity(params));
 
@@ -139,7 +139,7 @@ public class AgpClient implements Closeable {
     HttpPost req = new HttpPost(builder.build());
     
     Map<String, String> params = makeStdParams(title, description, itemType, thumbnailUrl, extent, typeKeywords, tags, token);
-    params.put("url", url.toExternalForm());
+    params.put(itemType.getDataType().name().toLowerCase(), url.toExternalForm());
     
     req.setEntity(createEntity(params));
 

--- a/geoportal-commons/geoportal-commons-constants/src/main/java/com/esri/geoportal/commons/constants/ItemType.java
+++ b/geoportal-commons/geoportal-commons-constants/src/main/java/com/esri/geoportal/commons/constants/ItemType.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Pattern;
+import java.util.stream.Stream;
 
 /**
  * Item types.
@@ -172,6 +173,23 @@ public enum ItemType {
    */
   public String getServiceType() {
     return serviceType;
+  }
+  
+  public boolean hasUniqueMimeType() {
+    if (getMimeTypes()==null || getMimeTypes().length==0) {
+      return true;
+    }
+    return Stream.of(ItemType.values())
+            .filter(it -> it!=this)
+            .filter(it -> {
+              if (it.getMimeTypes()==null) {
+                return false;
+              }
+              return Stream.of(it.getMimeTypes()).filter(mt -> {
+                return Stream.of(this.getMimeTypes()).filter(x -> x==mt).count() > 0;
+              }).count() > 0;
+             })
+            .count() == 0;
   }
   
   /**

--- a/geoportal-commons/geoportal-commons-dcat-client/src/main/java/com/esri/geoportal/commons/dcat/client/DcatParserAdaptor.java
+++ b/geoportal-commons/geoportal-commons-dcat-client/src/main/java/com/esri/geoportal/commons/dcat/client/DcatParserAdaptor.java
@@ -71,10 +71,9 @@ public class DcatParserAdaptor implements Iterable<DcatRecord> {
   
   /**
    * Called upon parsing exception thrown during iteration.
-   * @param ex 
+   * @param ex exception to handle
    */
   protected void onException(Exception ex) {
-    // TODO: override if needed
     LOGGER.log(Level.SEVERE, "Error parsing DCAT response.", ex);
   }
   

--- a/geoportal-commons/geoportal-commons-meta/src/main/java/com/esri/geoportal/commons/meta/Attribute.java
+++ b/geoportal-commons/geoportal-commons-meta/src/main/java/com/esri/geoportal/commons/meta/Attribute.java
@@ -15,9 +15,7 @@
  */
 package com.esri.geoportal.commons.meta;
 
-import java.util.Arrays;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 /**
  * Attribute.

--- a/geoportal-commons/geoportal-commons-meta/src/main/java/com/esri/geoportal/commons/meta/Attribute.java
+++ b/geoportal-commons/geoportal-commons-meta/src/main/java/com/esri/geoportal/commons/meta/Attribute.java
@@ -15,7 +15,14 @@
  */
 package com.esri.geoportal.commons.meta;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.apache.commons.lang3.tuple.ImmutablePair;
 
 /**
  * Attribute.
@@ -56,4 +63,32 @@ public interface Attribute {
    * @return array of attributes
    */
   default Attribute[] getAttributes() { return null; }
+  
+  /**
+   * Scans attribute for matching sub-attributes.
+   * @param pred predicate
+   * @return stream of matching attributes
+   */
+  default Stream<Map.Entry<String, Attribute>> scan(Predicate<Map.Entry<String, Attribute>> pred) {
+    ArrayList<Map.Entry<String, Attribute>> attributes = new ArrayList<>();
+    
+    Map.Entry<String, Attribute> thisAttribute = new ImmutablePair<>(null, this);
+    if (pred.test(thisAttribute)) {
+      attributes.add(thisAttribute);
+    }
+    
+    Map<String, Attribute> namedAttributes = getNamedAttributes();
+    if (namedAttributes!=null) {
+      attributes.addAll(namedAttributes.entrySet().stream().filter(e->pred.test(e)).collect(Collectors.toList()));
+      attributes.addAll(namedAttributes.entrySet().stream().flatMap(e->e.getValue().scan(pred)).collect(Collectors.toList()));
+    }
+    
+    Attribute[] arrAttributes = getAttributes();
+    if (arrAttributes!=null) {
+      attributes.addAll(Arrays.stream(arrAttributes).map(attr->new ImmutablePair<String,Attribute>(null, attr)).filter(e->pred.test(e)).collect(Collectors.toList()));
+      attributes.addAll(Arrays.stream(arrAttributes).flatMap(attr->attr.scan(pred)).collect(Collectors.toList()));
+    }
+    
+    return attributes.stream();
+  }
 }

--- a/geoportal-connectors/geoportal-harvester-agp-publisher/src/main/java/com/esri/geoportal/harvester/agp/AgpConstants.java
+++ b/geoportal-connectors/geoportal-harvester-agp-publisher/src/main/java/com/esri/geoportal/harvester/agp/AgpConstants.java
@@ -19,8 +19,9 @@ package com.esri.geoportal.harvester.agp;
  * AGP constants.
  */
 /*package*/ final class AgpConstants {
-  public static final String P_HOST_URL    = "agp-host-url";
-  public static final String P_FOLDER_ID   = "agp-folder-id";
+  public static final String P_HOST_URL       = "agp-host-url";
+  public static final String P_FOLDER_ID      = "agp-folder-id";
   public static final String P_FOLDER_CLEANUP = "agp-folder-cleanup";
-  public static final String P_MAX_REDIRECTS = "agp-max-redirects";
+  public static final String P_MAX_REDIRECTS  = "agp-max-redirects";
+  public static final String P_UPLOAD         = "agp-upload";
 }

--- a/geoportal-connectors/geoportal-harvester-agp-publisher/src/main/java/com/esri/geoportal/harvester/agp/AgpOutputBroker.java
+++ b/geoportal-connectors/geoportal-harvester-agp-publisher/src/main/java/com/esri/geoportal/harvester/agp/AgpOutputBroker.java
@@ -178,7 +178,8 @@ import org.xml.sax.SAXException;
                   sThumbnailUrl != null ? new URL(sThumbnailUrl) : null,
                   itemType,
                   extractEnvelope(bbox),
-                  typeKeywords
+                  typeKeywords,
+                  fileToUpload
           );
 
           if (response == null || !response.success) {
@@ -208,7 +209,8 @@ import org.xml.sax.SAXException;
                   sThumbnailUrl != null ? new URL(sThumbnailUrl) : null,
                   itemType,
                   extractEnvelope(bbox),
-                  typeKeywords
+                  typeKeywords,
+                  fileToUpload
           );
 
           if (response == null || !response.success) {
@@ -333,7 +335,7 @@ import org.xml.sax.SAXException;
     return attributes;
   }
 
-  private ItemResponse addItem(String title, String description, URL url, URL thumbnailUrl, ItemType itemType, Double[] envelope, String[] typeKeywords) throws IOException, URISyntaxException {
+  private ItemResponse addItem(String title, String description, URL url, URL thumbnailUrl, ItemType itemType, Double[] envelope, String[] typeKeywords, File fileToUpload) throws IOException, URISyntaxException {
     if (token == null) {
       token = generateToken();
     }
@@ -341,29 +343,29 @@ import org.xml.sax.SAXException;
             title,
             description,
             url, thumbnailUrl,
-            itemType, envelope, typeKeywords, token);
+            itemType, envelope, typeKeywords, fileToUpload, token);
     if (response.error != null && response.error.code == 498) {
       token = generateToken();
       response = addItem(
               title,
               description,
               url, thumbnailUrl,
-              itemType, envelope, typeKeywords, token);
+              itemType, envelope, typeKeywords, fileToUpload, token);
     }
     return response;
   }
 
-  private ItemResponse addItem(String title, String description, URL url, URL thumbnailUrl, ItemType itemType, Double[] envelope, String[] typeKeywords, String token) throws IOException, URISyntaxException {
+  private ItemResponse addItem(String title, String description, URL url, URL thumbnailUrl, ItemType itemType, Double[] envelope, String[] typeKeywords, File fileToUpload, String token) throws IOException, URISyntaxException {
     return client.addItem(
             definition.getCredentials().getUserName(),
             definition.getFolderId(),
             title,
             description,
             url, thumbnailUrl,
-            itemType, envelope, typeKeywords, null, token);
+            itemType, envelope, typeKeywords, null, fileToUpload, token);
   }
 
-  private ItemResponse updateItem(String id, String owner, String folderId, String title, String description, URL url, URL thumbnailUrl, ItemType itemType, Double[] envelope, String[] typeKeywords) throws IOException, URISyntaxException {
+  private ItemResponse updateItem(String id, String owner, String folderId, String title, String description, URL url, URL thumbnailUrl, ItemType itemType, Double[] envelope, String[] typeKeywords, File fileToUpload) throws IOException, URISyntaxException {
     if (token == null) {
       token = generateToken();
     }
@@ -374,7 +376,7 @@ import org.xml.sax.SAXException;
             title,
             description,
             url, thumbnailUrl,
-            itemType, envelope, typeKeywords, token);
+            itemType, envelope, typeKeywords, fileToUpload, token);
     if (response.error != null && response.error.code == 498) {
       token = generateToken();
       response = updateItem(
@@ -384,12 +386,12 @@ import org.xml.sax.SAXException;
               title,
               description,
               url, thumbnailUrl,
-              itemType, envelope, typeKeywords, token);
+              itemType, envelope, typeKeywords, fileToUpload, token);
     }
     return response;
   }
 
-  private ItemResponse updateItem(String id, String owner, String folderId, String title, String description, URL url, URL thumbnailUrl, ItemType itemType, Double[] envelope, String[] typeKeywords, String token) throws IOException, URISyntaxException {
+  private ItemResponse updateItem(String id, String owner, String folderId, String title, String description, URL url, URL thumbnailUrl, ItemType itemType, Double[] envelope, String[] typeKeywords, File fileToUpload, String token) throws IOException, URISyntaxException {
     return client.updateItem(
             owner,
             folderId,
@@ -397,7 +399,7 @@ import org.xml.sax.SAXException;
             title,
             description,
             url, thumbnailUrl,
-            itemType, envelope, typeKeywords, null, token);
+            itemType, envelope, typeKeywords, null, fileToUpload, token);
   }
 
   private DeleteResponse deleteItem(String id, String owner, String folderId) throws URISyntaxException, IOException {

--- a/geoportal-connectors/geoportal-harvester-agp-publisher/src/main/java/com/esri/geoportal/harvester/agp/AgpOutputBroker.java
+++ b/geoportal-connectors/geoportal-harvester-agp-publisher/src/main/java/com/esri/geoportal/harvester/agp/AgpOutputBroker.java
@@ -505,7 +505,9 @@ import org.xml.sax.SAXException;
           deleteItem(item.id, item.owner, item.ownerFolder);
         }
       }
-      client.close();
+      if (client!=null) {
+        client.close();
+      }
     } catch (IOException | URISyntaxException ex) {
       LOG.error(String.format("Error terminating broker."), ex);
     }

--- a/geoportal-connectors/geoportal-harvester-agp-publisher/src/main/java/com/esri/geoportal/harvester/agp/AgpOutputBroker.java
+++ b/geoportal-connectors/geoportal-harvester-agp-publisher/src/main/java/com/esri/geoportal/harvester/agp/AgpOutputBroker.java
@@ -95,13 +95,13 @@ import org.xml.sax.SAXException;
     this.definition = definition;
     this.metaAnalyzer = metaAnalyzer;
   }
-  
+
   @Override
   public PublishingStatus publish(DataReference ref) throws DataOutputException {
     try {
       // extract map of attributes (normalized names)
       MapAttribute attributes = extractMapAttributes(ref);
-      
+
       if (attributes == null) {
         throw new DataOutputException(this, ref.getId(), String.format("Error extracting attributes from data."));
       }
@@ -120,83 +120,85 @@ import org.xml.sax.SAXException;
         String.format("src_uri_s=%s", src_uri_s),
         String.format("src_lastupdate_dt=%s", src_lastupdate_dt)
       };
-      
+
+      String title = getAttributeValue(attributes, WKAConstants.WKA_TITLE, null);
+      String description = getAttributeValue(attributes, WKAConstants.WKA_DESCRIPTION, null);
+      String sThumbnailUrl = StringUtils.trimToNull(getAttributeValue(attributes, WKAConstants.WKA_THUMBNAIL_URL, null));
+      String resourceUrl = getAttributeValue(attributes, WKAConstants.WKA_RESOURCE_URL, null);
+      String bbox = getAttributeValue(attributes, WKAConstants.WKA_BBOX, null);
+
+      // If the WKA_RESOURCE_URL is empty after parsing the XML file, see if it was set on the 
+      // DataReference directly.
+      if (resourceUrl == null || resourceUrl.isEmpty()) {
+        resourceUrl = ((URI) ref.getAttributesMap().get(WKAConstants.WKA_RESOURCE_URL)).toString();
+      }
+
+      // check if the item is eligible for publishing
+      ItemType itemType = createItemType(resourceUrl);
+      // skip if no item type
+      if (itemType == null) {
+        return PublishingStatus.SKIPPED;
+      }
+
       try {
 
         // generate token
         if (token == null) {
           token = generateToken();
         }
-       
-        String urlStr = getAttributeValue(attributes, WKAConstants.WKA_RESOURCE_URL, null);
-
-        // If the WKA_RESOURCE_URL is empty after parsing the XML file, see if it was set on the 
-        // DataReference directly.
-        if (urlStr == null || urlStr.isEmpty()) {
-          urlStr = ((URI)ref.getAttributesMap().get(WKAConstants.WKA_RESOURCE_URL)).toString();
-        }
-
-        URL resourceUrl = new URL(urlStr);
-
-        ItemType itemType = Stream.concat(
-                ItemType.matchExt(resourceUrl.toExternalForm().substring(resourceUrl.toExternalForm().lastIndexOf(".")+1)).stream(), 
-                ItemType.matchPattern(resourceUrl.toExternalForm()).stream()
-        ).findFirst().orElse(null);
-        
-        if (itemType == null) {
-          return PublishingStatus.SKIPPED;
-        }
-        
-        switch (itemType.getDataType()) {
-          case Text:
-            return PublishingStatus.SKIPPED;
-          case File:
-            if (!itemType.hasUniqueMimeType()) {
-              return PublishingStatus.SKIPPED;
-            }
-            break;
-        }
-        
-        // find thumbnail URL
-        String sThumbnailUrl = StringUtils.trimToNull(getAttributeValue(attributes, WKAConstants.WKA_THUMBNAIL_URL, null));
-        URL thumbnailUrl = sThumbnailUrl!=null? new URL(sThumbnailUrl): null;
 
         // check if item exists
-        QueryResponse search = client.search(String.format("typekeywords:%s", String.format("src_uri_s=%s", src_uri_s)), 0, 0, token);
-        ItemEntry itemEntry = search!=null && search.results!=null && search.results.length>0? search.results[0]: null;
-        
-        if (itemEntry==null) {
+        ItemEntry itemEntry = searchForItem(src_uri_s);
+
+        if (itemEntry == null) {
           // add item if doesn't exist
-          ItemResponse response = addItem(getAttributeValue(attributes, WKAConstants.WKA_TITLE, null),
-                  getAttributeValue(attributes, WKAConstants.WKA_DESCRIPTION, null),
-                  resourceUrl, thumbnailUrl, 
-                  itemType, extractEnvelope(getAttributeValue(attributes, WKAConstants.WKA_BBOX, null)), typeKeywords);
+          ItemResponse response = addItem(
+                  title,
+                  description,
+                  new URL(resourceUrl),
+                  sThumbnailUrl != null ? new URL(sThumbnailUrl) : null,
+                  itemType,
+                  extractEnvelope(bbox),
+                  typeKeywords
+          );
 
           if (response == null || !response.success) {
-            String error = response!=null && response.error!=null && response.error.message!=null? response.error.message: null;
-            throw new DataOutputException(this, ref.getId(), String.format("Error adding item: %s%s", ref, error!=null? "; "+error: ""));
+            String error = response != null && response.error != null && response.error.message != null ? response.error.message : null;
+            throw new DataOutputException(this, ref.getId(), String.format("Error adding item: %s%s", ref, error != null ? "; " + error : ""));
           }
-          
+
           client.share(definition.getCredentials().getUserName(), definition.getFolderId(), response.id, true, true, null, token);
 
           return PublishingStatus.CREATED;
+
         } else if (itemEntry.owner.equals(definition.getCredentials().getUserName())) {
+
           itemEntry = client.readItem(itemEntry.id, token);
-          if (itemEntry==null) {
+          if (itemEntry == null) {
             throw new DataOutputException(this, ref.getId(), String.format("Unable to read item entry."));
           }
+
           // update item if does exist
-          ItemResponse response = updateItem(itemEntry.id,
+          ItemResponse response = updateItem(
+                  itemEntry.id,
                   itemEntry.owner,
                   itemEntry.ownerFolder,
-                  getAttributeValue(attributes, WKAConstants.WKA_TITLE, null),
-                  getAttributeValue(attributes, WKAConstants.WKA_DESCRIPTION, null),
-                  resourceUrl, thumbnailUrl,
-                  itemType, extractEnvelope(getAttributeValue(attributes, WKAConstants.WKA_BBOX, null)), typeKeywords);
+                  title,
+                  description,
+                  new URL(resourceUrl),
+                  sThumbnailUrl != null ? new URL(sThumbnailUrl) : null,
+                  itemType,
+                  extractEnvelope(bbox),
+                  typeKeywords
+          );
+
           if (response == null || !response.success) {
-            throw new DataOutputException(this, ref.getId(), String.format("Error updating item: %s", ref));
+            String error = response != null && response.error != null && response.error.message != null ? response.error.message : null;
+            throw new DataOutputException(this, ref.getId(), String.format("Error adding item: %s%s", ref, error != null ? "; " + error : ""));
           }
+
           existing.remove(itemEntry.id);
+
           return PublishingStatus.UPDATED;
         } else {
           return PublishingStatus.SKIPPED;
@@ -209,75 +211,107 @@ import org.xml.sax.SAXException;
       throw new DataOutputException(this, ref.getId(), String.format("Error publishing data: %s", ref), ex);
     }
   }
-  
-  private Double [] extractEnvelope(String sBbox) {
-    Double [] envelope = null;
-    if (sBbox!=null) {
+  private ItemType createItemType(String resourceUrl) {
+
+    // check if the item is eligible for publishing
+    ItemType itemType = Stream.concat(
+            ItemType.matchExt(resourceUrl.substring(resourceUrl.lastIndexOf(".") + 1)).stream(),
+            ItemType.matchPattern(resourceUrl).stream()
+    ).findFirst().orElse(null);
+
+    if (itemType == null) {
+      return null;
+    }
+
+    switch (itemType.getDataType()) {
+      case Text:
+        return null;
+      case File:
+        if (!itemType.hasUniqueMimeType()) {
+          return null;
+        }
+        break;
+    }
+
+    return itemType;
+  }
+
+  private ItemEntry searchForItem(String src_uri_s) throws URISyntaxException, IOException {
+
+    QueryResponse search = client.search(String.format("typekeywords:%s", String.format("src_uri_s=%s", src_uri_s)), 0, 0, token);
+    ItemEntry itemEntry = search != null && search.results != null && search.results.length > 0 ? search.results[0] : null;
+    
+    return itemEntry;
+  }
+
+  private Double[] extractEnvelope(String sBbox) {
+    Double[] envelope = null;
+    if (sBbox != null) {
       String[] corners = sBbox.split(",");
-      if (corners!=null && corners.length==2) {
-        String [] minXminY = corners[0].split(" ");
-        String [] maxXmaxY = corners[1].split(" ");
-        if (minXminY!=null && minXminY.length==2 && maxXmaxY!=null && maxXmaxY.length==2) {
+      if (corners != null && corners.length == 2) {
+        String[] minXminY = corners[0].split(" ");
+        String[] maxXmaxY = corners[1].split(" ");
+        if (minXminY != null && minXminY.length == 2 && maxXmaxY != null && maxXmaxY.length == 2) {
           minXminY[0] = StringUtils.trimToEmpty(minXminY[0]);
           minXminY[1] = StringUtils.trimToEmpty(minXminY[1]);
           maxXmaxY[0] = StringUtils.trimToEmpty(maxXmaxY[0]);
           maxXmaxY[1] = StringUtils.trimToEmpty(maxXmaxY[1]);
 
-          Double minX = NumberUtils.isNumber(minXminY[0])? NumberUtils.createDouble(minXminY[0]): null;
-          Double minY = NumberUtils.isNumber(minXminY[1])? NumberUtils.createDouble(minXminY[1]): null;
-          Double maxX = NumberUtils.isNumber(maxXmaxY[0])? NumberUtils.createDouble(maxXmaxY[0]): null;
-          Double maxY = NumberUtils.isNumber(maxXmaxY[1])? NumberUtils.createDouble(maxXmaxY[1]): null;
+          Double minX = NumberUtils.isNumber(minXminY[0]) ? NumberUtils.createDouble(minXminY[0]) : null;
+          Double minY = NumberUtils.isNumber(minXminY[1]) ? NumberUtils.createDouble(minXminY[1]) : null;
+          Double maxX = NumberUtils.isNumber(maxXmaxY[0]) ? NumberUtils.createDouble(maxXmaxY[0]) : null;
+          Double maxY = NumberUtils.isNumber(maxXmaxY[1]) ? NumberUtils.createDouble(maxXmaxY[1]) : null;
 
-          if (minX!=null && minY!=null && maxX!=null && maxY!=null) {
-            envelope = new Double[]{minX,minY,maxX,maxY};
+          if (minX != null && minY != null && maxX != null && maxY != null) {
+            envelope = new Double[]{minX, minY, maxX, maxY};
           }
         }
       }
     }
     return envelope;
   }
-  
+
   private String getAttributeValue(MapAttribute attributes, String attributeName, String defaultValue) {
     Attribute attr = attributes.getNamedAttributes().get(attributeName);
     return attr != null ? attr.getValue() : defaultValue;
   }
 
   private MapAttribute extractMapAttributes(DataReference ref) throws MetaException, IOException, ParserConfigurationException, SAXException {
-      MapAttribute attributes = ref.getAttributesMap().values().stream()
-              .filter(o -> o instanceof MapAttribute)
-              .map(o -> (MapAttribute) o)
+    MapAttribute attributes = ref.getAttributesMap().values().stream()
+            .filter(o -> o instanceof MapAttribute)
+            .map(o -> (MapAttribute) o)
+            .findFirst()
+            .orElse(null);
+    if (attributes == null) {
+      Document doc = ref.getAttributesMap().values().stream()
+              .filter(o -> o instanceof Document)
+              .map(o -> (Document) o)
               .findFirst()
               .orElse(null);
-      if (attributes == null) {
-        Document doc = ref.getAttributesMap().values().stream()
-                .filter(o -> o instanceof Document)
-                .map(o -> (Document) o)
-                .findFirst()
-                .orElse(null);
-        if (doc != null) {
+      if (doc != null) {
+        attributes = metaAnalyzer.extract(doc);
+      } else {
+        if (ref.getContentType().contains(MimeType.APPLICATION_XML) || ref.getContentType().contains(MimeType.TEXT_XML)) {
+          String sXml = new String(ref.getContent(MimeType.APPLICATION_XML, MimeType.TEXT_XML), "UTF-8");
+          DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+          factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+          factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+          factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+          factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+          factory.setXIncludeAware(false);
+          factory.setExpandEntityReferences(false);
+          factory.setNamespaceAware(true);
+          DocumentBuilder builder = factory.newDocumentBuilder();
+          doc = builder.parse(new InputSource(new StringReader(sXml)));
           attributes = metaAnalyzer.extract(doc);
-        } else {
-          if (ref.getContentType().contains(MimeType.APPLICATION_XML) || ref.getContentType().contains(MimeType.TEXT_XML)) {
-            String sXml = new String(ref.getContent(MimeType.APPLICATION_XML, MimeType.TEXT_XML), "UTF-8");
-            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
-            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-            factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
-            factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
-            factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
-            factory.setXIncludeAware(false);
-            factory.setExpandEntityReferences(false);
-            factory.setNamespaceAware(true);
-            DocumentBuilder builder = factory.newDocumentBuilder();
-            doc = builder.parse(new InputSource(new StringReader(sXml)));
-            attributes = metaAnalyzer.extract(doc);
-          }
         }
       }
-      return attributes;
+    }
+    return attributes;
   }
 
-  private ItemResponse addItem(String title, String description, URL url, URL thumbnailUrl, ItemType itemType, Double [] envelope, String[] typeKeywords) throws IOException, URISyntaxException {
-    if (token==null) {
+  private ItemResponse addItem(String title, String description, URL url, URL thumbnailUrl, ItemType itemType, Double[] envelope, String[] typeKeywords) throws IOException, URISyntaxException {
+    if (token == null) {
       token = generateToken();
     }
     ItemResponse response = addItem(
@@ -296,7 +330,7 @@ import org.xml.sax.SAXException;
     return response;
   }
 
-  private ItemResponse addItem(String title, String description, URL url, URL thumbnailUrl, ItemType itemType, Double [] envelope, String[] typeKeywords, String token) throws IOException, URISyntaxException {
+  private ItemResponse addItem(String title, String description, URL url, URL thumbnailUrl, ItemType itemType, Double[] envelope, String[] typeKeywords, String token) throws IOException, URISyntaxException {
     return client.addItem(
             definition.getCredentials().getUserName(),
             definition.getFolderId(),
@@ -306,8 +340,8 @@ import org.xml.sax.SAXException;
             itemType, envelope, typeKeywords, null, token);
   }
 
-  private ItemResponse updateItem(String id, String owner, String folderId, String title, String description, URL url, URL thumbnailUrl, ItemType itemType, Double [] envelope, String[] typeKeywords) throws IOException, URISyntaxException {
-    if (token==null) {
+  private ItemResponse updateItem(String id, String owner, String folderId, String title, String description, URL url, URL thumbnailUrl, ItemType itemType, Double[] envelope, String[] typeKeywords) throws IOException, URISyntaxException {
+    if (token == null) {
       token = generateToken();
     }
     ItemResponse response = updateItem(
@@ -316,7 +350,7 @@ import org.xml.sax.SAXException;
             folderId,
             title,
             description,
-            url, thumbnailUrl, 
+            url, thumbnailUrl,
             itemType, envelope, typeKeywords, token);
     if (response.error != null && response.error.code == 498) {
       token = generateToken();
@@ -326,13 +360,13 @@ import org.xml.sax.SAXException;
               folderId,
               title,
               description,
-              url, thumbnailUrl, 
+              url, thumbnailUrl,
               itemType, envelope, typeKeywords, token);
     }
     return response;
   }
 
-  private ItemResponse updateItem(String id, String owner, String folderId, String title, String description, URL url, URL thumbnailUrl, ItemType itemType, Double [] envelope, String[] typeKeywords, String token) throws IOException, URISyntaxException {
+  private ItemResponse updateItem(String id, String owner, String folderId, String title, String description, URL url, URL thumbnailUrl, ItemType itemType, Double[] envelope, String[] typeKeywords, String token) throws IOException, URISyntaxException {
     return client.updateItem(
             owner,
             folderId,
@@ -342,9 +376,9 @@ import org.xml.sax.SAXException;
             url, thumbnailUrl,
             itemType, envelope, typeKeywords, null, token);
   }
-  
+
   private DeleteResponse deleteItem(String id, String owner, String folderId) throws URISyntaxException, IOException {
-    if (token==null) {
+    if (token == null) {
       token = generateToken();
     }
     DeleteResponse response = deleteItem(id, owner, folderId, token);
@@ -354,7 +388,7 @@ import org.xml.sax.SAXException;
     }
     return response;
   }
-  
+
   private DeleteResponse deleteItem(String id, String owner, String folderId, String token) throws URISyntaxException, IOException {
     return client.delete(id, owner, folderId, token);
   }
@@ -380,7 +414,7 @@ import org.xml.sax.SAXException;
   @Override
   public void initialize(InitContext context) throws DataProcessorException {
     definition.override(context.getParams());
-    this.client = new AgpClient(HttpClientBuilder.create().useSystemProperties().build(), definition.getHostUrl(),definition.getCredentials(), definition.getMaxRedirects());
+    this.client = new AgpClient(HttpClientBuilder.create().useSystemProperties().build(), definition.getHostUrl(), definition.getCredentials(), definition.getMaxRedirects());
 
     if (!context.canCleanup()) {
       preventCleanup = true;
@@ -395,29 +429,29 @@ import org.xml.sax.SAXException;
       try {
         String src_source_uri_s = URLEncoder.encode(context.getTask().getDataSource().getBrokerUri().toASCIIString(), "UTF-8");
         QueryResponse search = client.search(String.format("typekeywords:%s", String.format("src_source_uri_s=%s", src_source_uri_s)), 0, 0, generateToken(1));
-        while (search!=null && search.results!=null && search.results.length>0) {
-          existing.addAll(Arrays.asList(search.results).stream().map(i->i.id).collect(Collectors.toList()));
-          if (search.nextStart>0) {
+        while (search != null && search.results != null && search.results.length > 0) {
+          existing.addAll(Arrays.asList(search.results).stream().map(i -> i.id).collect(Collectors.toList()));
+          if (search.nextStart > 0) {
             search = client.search(String.format("typekeywords:%s", String.format("src_source_uri_s=%s", src_source_uri_s)), 0, search.nextStart, generateToken(1));
           } else {
             break;
           }
         }
-      } catch (URISyntaxException|IOException ex) {
+      } catch (URISyntaxException | IOException ex) {
         throw new DataProcessorException(String.format("Error collecting ids of existing items."), ex);
       }
     }
-    
+
     try {
       String folderId = StringUtils.trimToNull(definition.getFolderId());
-      if (folderId!=null) {
+      if (folderId != null) {
         FolderEntry[] folders = this.client.listFolders(definition.getCredentials().getUserName(), generateToken(1));
-        FolderEntry selectedFodler = folders!=null?
-                Arrays.stream(folders).filter(folder->folder.id!=null && folder.id.equals(folderId)).findFirst().orElse(
-                        Arrays.stream(folders).filter(folder->folder.title!=null && folder.title.equals(folderId)).findFirst().orElse(null)
-                ):
-                null;
-        if (selectedFodler!=null) {
+        FolderEntry selectedFodler = folders != null
+                ? Arrays.stream(folders).filter(folder -> folder.id != null && folder.id.equals(folderId)).findFirst().orElse(
+                        Arrays.stream(folders).filter(folder -> folder.title != null && folder.title.equals(folderId)).findFirst().orElse(null)
+                )
+                : null;
+        if (selectedFodler != null) {
           definition.setFolderId(selectedFodler.id);
         } else {
           definition.setFolderId(null);
@@ -425,7 +459,7 @@ import org.xml.sax.SAXException;
       } else {
         definition.setFolderId(null);
       }
-    } catch (IOException|URISyntaxException ex) {
+    } catch (IOException | URISyntaxException ex) {
       throw new DataProcessorException(String.format("Error listing folders for user: %s", definition.getCredentials().getUserName()), ex);
     }
   }
@@ -433,22 +467,22 @@ import org.xml.sax.SAXException;
   @Override
   public void terminate() {
     try {
-      if(definition.getCleanup() && !preventCleanup) {
+      if (definition.getCleanup() && !preventCleanup) {
         token = generateToken();
-        for (String id: existing) {
+        for (String id : existing) {
           ItemEntry item = client.readItem(id, token);
           deleteItem(item.id, item.owner, item.ownerFolder);
         }
       }
       client.close();
-    } catch (IOException|URISyntaxException ex) {
+    } catch (IOException | URISyntaxException ex) {
       LOG.error(String.format("Error terminating broker."), ex);
     }
   }
 
   @Override
   public boolean hasAccess(SimpleCredentials creds) {
-    return definition.getCredentials()==null || definition.getCredentials().isEmpty()? true: definition.getCredentials().equals(creds);
+    return definition.getCredentials() == null || definition.getCredentials().isEmpty() ? true : definition.getCredentials().equals(creds);
   }
 
   private String fromatDate(Date date) {

--- a/geoportal-connectors/geoportal-harvester-agp-publisher/src/main/java/com/esri/geoportal/harvester/agp/AgpOutputBroker.java
+++ b/geoportal-connectors/geoportal-harvester-agp-publisher/src/main/java/com/esri/geoportal/harvester/agp/AgpOutputBroker.java
@@ -155,8 +155,13 @@ import org.xml.sax.SAXException;
       
       // download file
       if (itemType.getDataType() == DataType.File && definition.isUploadFiles()) {
-        FileName fn = getFileNameFromUrl(resourceUrl);
-        fileToUpload = downloadFile(new URL(resourceUrl), fn);
+        try {
+          FileName fn = getFileNameFromUrl(resourceUrl);
+          fileToUpload = downloadFile(new URL(resourceUrl), fn);
+        } catch (IOException ex) {
+          LOG.debug(String.format("Error downloading file %s. Registering URL only.", resourceUrl), ex);
+          fileToUpload = null;
+        }
       }
 
       try {

--- a/geoportal-connectors/geoportal-harvester-agp-publisher/src/main/java/com/esri/geoportal/harvester/agp/AgpOutputBroker.java
+++ b/geoportal-connectors/geoportal-harvester-agp-publisher/src/main/java/com/esri/geoportal/harvester/agp/AgpOutputBroker.java
@@ -149,7 +149,7 @@ import org.xml.sax.SAXException;
       ItemType itemType = createItemType(resourceUrl);
       // skip if no item type
       if (itemType == null) {
-        LOG.info(String.format("Resource '%s' with resource url '%s' skipped for unrecognized item type", title, resourceUrl));
+        LOG.debug(String.format("Resource '%s' with resource url '%s' skipped for unrecognized item type", title, resourceUrl));
         return PublishingStatus.SKIPPED;
       }
       

--- a/geoportal-connectors/geoportal-harvester-agp-publisher/src/main/java/com/esri/geoportal/harvester/agp/AgpOutputBroker.java
+++ b/geoportal-connectors/geoportal-harvester-agp-publisher/src/main/java/com/esri/geoportal/harvester/agp/AgpOutputBroker.java
@@ -149,7 +149,7 @@ import org.xml.sax.SAXException;
       ItemType itemType = createItemType(resourceUrl);
       // skip if no item type
       if (itemType == null) {
-        LOG.debug(String.format("Resource '%s' skipped for unrecognized item type", title));
+        LOG.info(String.format("Resource '%s' with resource url '%s' skipped for unrecognized item type", title, resourceUrl));
         return PublishingStatus.SKIPPED;
       }
       
@@ -159,7 +159,7 @@ import org.xml.sax.SAXException;
           FileName fn = getFileNameFromUrl(resourceUrl);
           fileToUpload = downloadFile(new URL(resourceUrl), fn);
         } catch (IOException ex) {
-          LOG.debug(String.format("Error downloading file %s. Registering URL only.", resourceUrl), ex);
+          LOG.warn(String.format("Error downloading file '%s'. Registering URL only.", resourceUrl), ex);
           fileToUpload = null;
         }
       }

--- a/geoportal-connectors/geoportal-harvester-agp-publisher/src/main/java/com/esri/geoportal/harvester/agp/AgpOutputBroker.java
+++ b/geoportal-connectors/geoportal-harvester-agp-publisher/src/main/java/com/esri/geoportal/harvester/agp/AgpOutputBroker.java
@@ -46,7 +46,6 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.StringReader;
 import java.net.MalformedURLException;
-import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLEncoder;
@@ -150,14 +149,13 @@ import org.xml.sax.SAXException;
       ItemType itemType = createItemType(resourceUrl);
       // skip if no item type
       if (itemType == null) {
+        LOG.debug(String.format("Resource '%s' skipped for unrecognized item type", title));
         return PublishingStatus.SKIPPED;
       }
       
       // download file
-      String fileName = null;
       if (itemType.getDataType() == DataType.File && definition.isUploadFiles()) {
         FileName fn = getFileNameFromUrl(resourceUrl);
-        fileName = fn.getFullName();
         fileToUpload = downloadFile(new URL(resourceUrl), fn);
       }
 

--- a/geoportal-connectors/geoportal-harvester-agp-publisher/src/main/java/com/esri/geoportal/harvester/agp/AgpOutputBroker.java
+++ b/geoportal-connectors/geoportal-harvester-agp-publisher/src/main/java/com/esri/geoportal/harvester/agp/AgpOutputBroker.java
@@ -141,7 +141,9 @@ import org.xml.sax.SAXException;
       // If the WKA_RESOURCE_URL is empty after parsing the XML file, see if it was set on the 
       // DataReference directly.
       if (resourceUrl == null || resourceUrl.isEmpty()) {
-        resourceUrl = ((URI) ref.getAttributesMap().get(WKAConstants.WKA_RESOURCE_URL)).toString();
+        if (ref.getAttributesMap().get(WKAConstants.WKA_RESOURCE_URL) != null) {
+          resourceUrl = ref.getAttributesMap().get(WKAConstants.WKA_RESOURCE_URL).toString();
+        }
       }
 
       // check if the item is eligible for publishing

--- a/geoportal-connectors/geoportal-harvester-agp-publisher/src/main/java/com/esri/geoportal/harvester/agp/AgpOutputBroker.java
+++ b/geoportal-connectors/geoportal-harvester-agp-publisher/src/main/java/com/esri/geoportal/harvester/agp/AgpOutputBroker.java
@@ -143,8 +143,18 @@ import org.xml.sax.SAXException;
                 ItemType.matchPattern(resourceUrl.toExternalForm()).stream()
         ).findFirst().orElse(null);
         
-        if (itemType == null || itemType.getDataType()!=DataType.URL) {
+        if (itemType == null) {
           return PublishingStatus.SKIPPED;
+        }
+        
+        switch (itemType.getDataType()) {
+          case Text:
+            return PublishingStatus.SKIPPED;
+          case File:
+            if (!itemType.hasUniqueMimeType()) {
+              return PublishingStatus.SKIPPED;
+            }
+            break;
         }
         
         // find thumbnail URL

--- a/geoportal-connectors/geoportal-harvester-agp-publisher/src/main/java/com/esri/geoportal/harvester/agp/AgpOutputBroker.java
+++ b/geoportal-connectors/geoportal-harvester-agp-publisher/src/main/java/com/esri/geoportal/harvester/agp/AgpOutputBroker.java
@@ -54,6 +54,7 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -137,7 +138,11 @@ import org.xml.sax.SAXException;
 
         URL resourceUrl = new URL(urlStr);
 
-        ItemType itemType = ItemType.matchPattern(resourceUrl.toExternalForm()).stream().findFirst().orElse(null);
+        ItemType itemType = Stream.concat(
+                ItemType.matchExt(resourceUrl.toExternalForm().substring(resourceUrl.toExternalForm().lastIndexOf(".")+1)).stream(), 
+                ItemType.matchPattern(resourceUrl.toExternalForm()).stream()
+        ).findFirst().orElse(null);
+        
         if (itemType == null || itemType.getDataType()!=DataType.URL) {
           return PublishingStatus.SKIPPED;
         }

--- a/geoportal-connectors/geoportal-harvester-agp-publisher/src/main/java/com/esri/geoportal/harvester/agp/AgpOutputBroker.java
+++ b/geoportal-connectors/geoportal-harvester-agp-publisher/src/main/java/com/esri/geoportal/harvester/agp/AgpOutputBroker.java
@@ -173,7 +173,8 @@ import org.xml.sax.SAXException;
                   itemType, extractEnvelope(getAttributeValue(attributes, WKAConstants.WKA_BBOX, null)), typeKeywords);
 
           if (response == null || !response.success) {
-            throw new DataOutputException(this, ref.getId(), String.format("Error adding item: %s", ref));
+            String error = response!=null && response.error!=null && response.error.message!=null? response.error.message: null;
+            throw new DataOutputException(this, ref.getId(), String.format("Error adding item: %s%s", ref, error!=null? "; "+error: ""));
           }
           
           client.share(definition.getCredentials().getUserName(), definition.getFolderId(), response.id, true, true, null, token);

--- a/geoportal-connectors/geoportal-harvester-agp-publisher/src/main/java/com/esri/geoportal/harvester/agp/AgpOutputBroker.java
+++ b/geoportal-connectors/geoportal-harvester-agp-publisher/src/main/java/com/esri/geoportal/harvester/agp/AgpOutputBroker.java
@@ -583,6 +583,7 @@ import org.xml.sax.SAXException;
       return ext!=null? name + "." + ext: name;
     }
     
+    @Override
     public String toString() {
       return getFullName();
     }

--- a/geoportal-connectors/geoportal-harvester-agp-publisher/src/main/java/com/esri/geoportal/harvester/agp/AgpOutputBrokerDefinitionAdaptor.java
+++ b/geoportal-connectors/geoportal-harvester-agp-publisher/src/main/java/com/esri/geoportal/harvester/agp/AgpOutputBrokerDefinitionAdaptor.java
@@ -30,24 +30,27 @@ import org.apache.commons.lang3.math.NumberUtils;
 /**
  * ArcGIS Portal definition adaptor.
  */
-/*package*/ class AgpOutputBrokerDefinitionAdaptor  extends BrokerDefinitionAdaptor {
+/*package*/ class AgpOutputBrokerDefinitionAdaptor extends BrokerDefinitionAdaptor {
+
   private static final Integer DEFAULT_MAX_REDIRECTS = 5;
 
   private final CredentialsDefinitionAdaptor credAdaptor;
-  
+
   private URL hostUrl;
   private String folderId;
   private boolean cleanup;
   private Integer maxRedirects;
+  private boolean uploadFiles;
 
   /**
    * Creates instance of the adaptor.
+   *
    * @param def broker definition
    * @throws IllegalArgumentException if invalid broker definition
    */
   public AgpOutputBrokerDefinitionAdaptor(EntityDefinition def) throws InvalidDefinitionException {
     super(def);
-    this.credAdaptor =new CredentialsDefinitionAdaptor(def);
+    this.credAdaptor = new CredentialsDefinitionAdaptor(def);
     if (credAdaptor.getCredentials().isEmpty()) {
       throw new InvalidDefinitionException("Empty credentials");
     }
@@ -59,33 +62,37 @@ import org.apache.commons.lang3.math.NumberUtils;
       try {
         hostUrl = new URL(get(P_HOST_URL));
       } catch (MalformedURLException ex) {
-        throw new InvalidDefinitionException(String.format("Invalid %s: %s", P_HOST_URL,get(P_HOST_URL)), ex);
+        throw new InvalidDefinitionException(String.format("Invalid %s: %s", P_HOST_URL, get(P_HOST_URL)), ex);
       }
       folderId = get(P_FOLDER_ID);
-      cleanup  = Boolean.parseBoolean(get(P_FOLDER_CLEANUP));
+      cleanup = Boolean.parseBoolean(get(P_FOLDER_CLEANUP));
       maxRedirects = NumberUtils.toInt(get(P_MAX_REDIRECTS), DEFAULT_MAX_REDIRECTS);
+      uploadFiles = Boolean.parseBoolean(get(P_UPLOAD));
     }
   }
 
   @Override
   public void override(Map<String, String> params) {
-    consume(params,P_HOST_URL);
-    consume(params,P_FOLDER_ID);
-    consume(params,P_FOLDER_CLEANUP);
+    consume(params, P_HOST_URL);
+    consume(params, P_FOLDER_ID);
+    consume(params, P_FOLDER_CLEANUP);
     consume(params, P_MAX_REDIRECTS);
+    consume(params, P_UPLOAD);
     credAdaptor.override(params);
   }
-  
+
   /**
    * Gets host URL.
+   *
    * @return host URL
    */
   public URL getHostUrl() {
     return hostUrl;
   }
-  
+
   /**
    * Sets host URL
+   *
    * @param url host URL
    */
   public void setHostUrl(URL url) {
@@ -95,6 +102,7 @@ import org.apache.commons.lang3.math.NumberUtils;
 
   /**
    * Gets folder id.
+   *
    * @return folder id
    */
   public String getFolderId() {
@@ -103,7 +111,8 @@ import org.apache.commons.lang3.math.NumberUtils;
 
   /**
    * Sets folder id.
-   * @param folderId folder id 
+   *
+   * @param folderId folder id
    */
   public void setFolderId(String folderId) {
     this.folderId = folderId;
@@ -112,6 +121,7 @@ import org.apache.commons.lang3.math.NumberUtils;
 
   /**
    * Gets credentials.
+   *
    * @return credentials
    */
   public SimpleCredentials getCredentials() {
@@ -120,6 +130,7 @@ import org.apache.commons.lang3.math.NumberUtils;
 
   /**
    * Sets credentials.
+   *
    * @param cred credentials
    */
   public void setCredentials(SimpleCredentials cred) {
@@ -128,6 +139,7 @@ import org.apache.commons.lang3.math.NumberUtils;
 
   /**
    * Gets permission to cleanup.
+   *
    * @return <code>true</code> if cleanup permitted
    */
   public boolean getCleanup() {
@@ -136,6 +148,7 @@ import org.apache.commons.lang3.math.NumberUtils;
 
   /**
    * Sets permission to cleanup.
+   *
    * @param cleanup <code>true</code> to permit cleanup
    */
   public void setCleanup(boolean cleanup) {
@@ -143,19 +156,30 @@ import org.apache.commons.lang3.math.NumberUtils;
     set(P_FOLDER_CLEANUP, Boolean.toString(cleanup));
   }
 
-/**
- * @return the maxRedirects
- */
-public Integer getMaxRedirects() {
-	return maxRedirects;
-}
+  /**
+   * Gets maximum of redirects.
+   * @return the maxRedirects
+   */
+  public Integer getMaxRedirects() {
+    return maxRedirects;
+  }
 
-/**
- * @param maxRedirects the maxRedirects to set
- */
-public void setMaxRedirects(Integer maxRedirects) {
-	this.maxRedirects = maxRedirects;
-}
-  
-  
+  /**
+   * Sets maximum of redirects.
+   * @param maxRedirects the maxRedirects to set
+   */
+  public void setMaxRedirects(Integer maxRedirects) {
+    this.maxRedirects = maxRedirects;
+    set(P_MAX_REDIRECTS, Integer.toString(maxRedirects));
+  }
+
+  public boolean isUploadFiles() {
+    return uploadFiles;
+  }
+
+  public void setUploadFiles(boolean uploadFiles) {
+    this.uploadFiles = uploadFiles;
+    set(P_UPLOAD, Boolean.toString(uploadFiles));
+  }
+
 }

--- a/geoportal-connectors/geoportal-harvester-agp-publisher/src/main/java/com/esri/geoportal/harvester/agp/AgpOutputConnector.java
+++ b/geoportal-connectors/geoportal-harvester-agp-publisher/src/main/java/com/esri/geoportal/harvester/agp/AgpOutputConnector.java
@@ -77,7 +77,8 @@ public class AgpOutputConnector implements OutputConnector<OutputBroker> {
       }
     });
     args.add(new UITemplate.IntegerArgument(P_MAX_REDIRECTS, bundle.getString("agp.max.redirects"), false, 5));
-    args.add(new UITemplate.BooleanArgument(P_FOLDER_CLEANUP, "Perform cleanup"));
+    args.add(new UITemplate.BooleanArgument(P_FOLDER_CLEANUP, bundle.getString("agp.cleanup")));
+    args.add(new UITemplate.BooleanArgument(P_UPLOAD, bundle.getString("agp.upload")));
     return new UITemplate(getType(), bundle.getString("agp"), args);
   }
   

--- a/geoportal-connectors/geoportal-harvester-agp-publisher/src/main/java/com/esri/geoportal/harvester/agp/AgpOutputConnector.java
+++ b/geoportal-connectors/geoportal-harvester-agp-publisher/src/main/java/com/esri/geoportal/harvester/agp/AgpOutputConnector.java
@@ -78,7 +78,7 @@ public class AgpOutputConnector implements OutputConnector<OutputBroker> {
     });
     args.add(new UITemplate.IntegerArgument(P_MAX_REDIRECTS, bundle.getString("agp.max.redirects"), false, 5));
     args.add(new UITemplate.BooleanArgument(P_FOLDER_CLEANUP, bundle.getString("agp.cleanup")));
-    args.add(new UITemplate.BooleanArgument(P_UPLOAD, bundle.getString("agp.upload")));
+    args.add(new UITemplate.BooleanArgument(P_UPLOAD, bundle.getString("agp.upload"), true, true));
     return new UITemplate(getType(), bundle.getString("agp"), args);
   }
   

--- a/geoportal-connectors/geoportal-harvester-agp-publisher/src/main/resources/AgpResource.properties
+++ b/geoportal-connectors/geoportal-harvester-agp-publisher/src/main/resources/AgpResource.properties
@@ -20,3 +20,4 @@ agp.password = user password
 agp.cleanup = Perform cleanup
 agp.max.redirects = Maximum redirects
 agp.hint = http://www.arcgis.com
+agp.upload = Upload files

--- a/geoportal-connectors/geoportal-harvester-agp-source/src/main/java/com/esri/geoportal/harvester/agpsrc/AgpInputBroker.java
+++ b/geoportal-connectors/geoportal-harvester-agp-source/src/main/java/com/esri/geoportal/harvester/agpsrc/AgpInputBroker.java
@@ -167,10 +167,12 @@ import com.esri.geoportal.harvester.api.defs.TaskDefinition;
 
   @Override
   public void terminate() {
-    try {
-      client.close();
-    } catch (IOException ex) {
-      LOG.error(String.format("Error terminating broker."), ex);
+    if (client!=null) {
+      try {
+        client.close();
+      } catch (IOException ex) {
+        LOG.error(String.format("Error terminating broker."), ex);
+      }
     }
   }
 

--- a/geoportal-connectors/geoportal-harvester-ags/src/main/java/com/esri/geoportal/harvester/ags/AgsBroker.java
+++ b/geoportal-connectors/geoportal-harvester-ags/src/main/java/com/esri/geoportal/harvester/ags/AgsBroker.java
@@ -119,10 +119,12 @@ import java.net.URL;
 
   @Override
   public void terminate() {
-    try {
-      client.close();
-    } catch (IOException ex) {
-      LOG.error(String.format("Error terminating broker."), ex);
+    if (client!=null) {
+      try {
+        client.close();
+      } catch (IOException ex) {
+        LOG.error(String.format("Error terminating broker."), ex);
+      }
     }
   }
 

--- a/geoportal-connectors/geoportal-harvester-gptsrc/src/main/java/com/esri/geoportal/harvester/gptsrc/GptBroker.java
+++ b/geoportal-connectors/geoportal-harvester-gptsrc/src/main/java/com/esri/geoportal/harvester/gptsrc/GptBroker.java
@@ -75,10 +75,12 @@ class GptBroker implements InputBroker {
 
   @Override
   public void terminate() {
-    try {
-      client.close();
-    } catch (IOException ex) {
-      LOG.error(String.format("Error terminating broker."), ex);
+    if (client!=null) {
+      try {
+        client.close();
+      } catch (IOException ex) {
+        LOG.error(String.format("Error terminating broker."), ex);
+      }
     }
   }
 

--- a/geoportal-connectors/geoportal-harvester-migration/src/main/java/com/esri/geoportal/harvester/migration/MigrationBroker.java
+++ b/geoportal-connectors/geoportal-harvester-migration/src/main/java/com/esri/geoportal/harvester/migration/MigrationBroker.java
@@ -46,7 +46,6 @@ import org.slf4j.LoggerFactory;
  */
 /*package*/ class MigrationBroker implements InputBroker {
   private static final Logger LOG = LoggerFactory.getLogger(MigrationBroker.class);
-  private static final int PAGE_SIZE = 10;
 
   private final MigrationConnector connector;
   private final MigrationBrokerDefinitionAdaptor definition;


### PR DESCRIPTION
This patch enables to download remote files then upload them into the ArcGIS Portal if platform can handle it (for example: pdf, cvs, docx, xlsx, etc.). This ability is optional and is activated by selecting checkbox on Portal output broker. 
If option is deactivated, broker will only register remote url. Also, if broker is unable to download file it will register url only.
Downloading have significant impact on performance of the harvesting.