### PR TITLE
THREDDS support.

### DIFF
--- a/geoportal-SDK/geoportal-harvester-api-base/src/main/java/com/esri/geoportal/harvester/api/base/DataReferenceWrapper.java
+++ b/geoportal-SDK/geoportal-harvester-api-base/src/main/java/com/esri/geoportal/harvester/api/base/DataReferenceWrapper.java
@@ -77,6 +77,11 @@ public class DataReferenceWrapper implements DataReference {
   }
 
   @Override
+  public String getFetchableId() {
+    return baseRef.getFetchableId();
+  }
+
+  @Override
   public Date getLastModifiedDate() {
     return baseRef.getLastModifiedDate();
   }

--- a/geoportal-SDK/geoportal-harvester-api-base/src/main/java/com/esri/geoportal/harvester/api/base/SimpleDataReference.java
+++ b/geoportal-SDK/geoportal-harvester-api-base/src/main/java/com/esri/geoportal/harvester/api/base/SimpleDataReference.java
@@ -27,7 +27,7 @@ import java.util.Set;
 /**
  * Simple data reference.
  */
-public final class SimpleDataReference implements DataReference {
+public class SimpleDataReference implements DataReference {
   private static final long serialVersionUID = 1L;
   
   // info
@@ -84,6 +84,11 @@ public final class SimpleDataReference implements DataReference {
 
   @Override
   public String getId() {
+    return id;
+  }
+
+  @Override
+  public String getFetchableId() {
     return id;
   }
 

--- a/geoportal-SDK/geoportal-harvester-api/src/main/java/com/esri/geoportal/harvester/api/DataReference.java
+++ b/geoportal-SDK/geoportal-harvester-api/src/main/java/com/esri/geoportal/harvester/api/DataReference.java
@@ -33,11 +33,17 @@ public interface DataReference extends Serializable, DataContent {
   String getId();
   
   /**
+   * Gets fetchable data record id.
+   * Fetchable data id is a convenient id used to fetch a single data from the source.
+   * @return fetchable data record id
+   */
+  String getFetchableId();
+  
+  /**
    * Gets last modified date.
    * @return last modified date or <code>null</code> if no date information available
    */
   Date getLastModifiedDate();
-  
   
   /**
    * Gets source URI.

--- a/geoportal-SDK/geoportal-harvester-api/src/main/java/com/esri/geoportal/harvester/api/ex/DataOutputException.java
+++ b/geoportal-SDK/geoportal-harvester-api/src/main/java/com/esri/geoportal/harvester/api/ex/DataOutputException.java
@@ -15,6 +15,7 @@
  */
 package com.esri.geoportal.harvester.api.ex;
 
+import com.esri.geoportal.harvester.api.DataReference;
 import com.esri.geoportal.harvester.api.specs.OutputBroker;
 
 /**
@@ -23,8 +24,8 @@ import com.esri.geoportal.harvester.api.specs.OutputBroker;
  * Exception associated with output broker.
  */
 public class DataOutputException extends DataException {
-  private final OutputBroker outputBroker;
-  private final String dataId;
+  protected final OutputBroker outputBroker;
+  protected final DataReference ref;
 
   /**
    * Gets data output.
@@ -39,7 +40,7 @@ public class DataOutputException extends DataException {
    * @return data id
    */
   public String getDataId() {
-    return dataId;
+    return ref.getId();
   }
 
   /**
@@ -47,13 +48,13 @@ public class DataOutputException extends DataException {
    * specified detail message.
    *
    * @param outputBroker output
-   * @param dataId data id
+   * @param ref data reference
    * @param msg the detail message.
    */
-  public DataOutputException(OutputBroker outputBroker, String dataId, String msg) {
+  public DataOutputException(OutputBroker outputBroker, DataReference ref, String msg) {
     super(msg);
-    this.dataId = dataId;
     this.outputBroker = outputBroker;
+    this.ref = ref;
   }
 
   /**
@@ -61,13 +62,13 @@ public class DataOutputException extends DataException {
    * specified detail message.
    *
    * @param outputBroker output
-   * @param dataId data id
+   * @param ref data reference
    * @param msg the detail message.
    * @param t cause
    */
-  public DataOutputException(OutputBroker outputBroker, String dataId, String msg, Throwable t) {
+  public DataOutputException(OutputBroker outputBroker, DataReference ref, String msg, Throwable t) {
     super(msg,t);
-    this.dataId = dataId;
     this.outputBroker = outputBroker;
+    this.ref = ref;
   }
 }

--- a/geoportal-SDK/geoportal-harvester-api/src/main/java/com/esri/geoportal/harvester/api/ex/DataOutputException.java
+++ b/geoportal-SDK/geoportal-harvester-api/src/main/java/com/esri/geoportal/harvester/api/ex/DataOutputException.java
@@ -44,6 +44,16 @@ public class DataOutputException extends DataException {
   }
 
   /**
+   * Gets fetchable data id.
+   * Fetchable data id is a convenient id used to fetch a single data from the source.
+   * @return fetchable data id
+   */
+  public String getFetchableDataId() {
+    return ref.getFetchableId();
+  }
+
+
+  /**
    * Constructs an instance of <code>DataOutputException</code> with the
    * specified detail message.
    *

--- a/geoportal-application/geoportal-harvester-cli/src/main/java/com/esri/geoportal/cli/boot/Bootstrap.java
+++ b/geoportal-application/geoportal-harvester-cli/src/main/java/com/esri/geoportal/cli/boot/Bootstrap.java
@@ -80,6 +80,7 @@ import java.net.URL;
 import javax.xml.transform.TransformerConfigurationException;
 import javax.xml.xpath.XPathExpressionException;
 import org.apache.http.impl.client.HttpClients;
+import com.esri.geoportal.harvester.thredds.ThreddsConnector;
 
 /**
  * Bootstrap.
@@ -273,6 +274,7 @@ public class Bootstrap {
       inboundConnectorRegistry.put(OaiConnector.TYPE, new OaiConnector());
       inboundConnectorRegistry.put(JdbcConnector.TYPE, new JdbcConnector(true));
       inboundConnectorRegistry.put(DcatConnector.TYPE, new DcatConnector(metaBuilder));
+      inboundConnectorRegistry.put(ThreddsConnector.TYPE, new ThreddsConnector());
     }
     
     return inboundConnectorRegistry;

--- a/geoportal-application/geoportal-harvester-engine/pom.xml
+++ b/geoportal-application/geoportal-harvester-engine/pom.xml
@@ -96,5 +96,10 @@
             <artifactId>geoportal-harvester-dcat</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>geoportal-harvester-thredds</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 </project>

--- a/geoportal-application/geoportal-harvester-engine/src/main/java/com/esri/geoportal/harvester/engine/defaults/DefaultTasksService.java
+++ b/geoportal-application/geoportal-harvester-engine/src/main/java/com/esri/geoportal/harvester/engine/defaults/DefaultTasksService.java
@@ -182,6 +182,7 @@ public class DefaultTasksService implements TasksService {
     InputBroker broker = null;
     try {
       TaskDefinition taskDefinition = readTaskDefinition(taskId);
+      taskDefinition.setIgnoreRobotsTxt(true);
       Task task = this.createTask(taskDefinition);
       
       if (!task.getDataSource().hasAccess(credentials)) {

--- a/geoportal-application/geoportal-harvester-engine/src/main/java/com/esri/geoportal/harvester/engine/utils/HistoryManagerAdaptor.java
+++ b/geoportal-application/geoportal-harvester-engine/src/main/java/com/esri/geoportal/harvester/engine/utils/HistoryManagerAdaptor.java
@@ -113,7 +113,7 @@ public class HistoryManagerAdaptor extends BaseProcessInstanceListener {
       report.failedToPublish ++;
       DataOutputException outex = (DataOutputException) dataOutputException;
       try {
-        historyManager.storeFailedDataId(event.getUuid(), outex.getDataId());
+        historyManager.storeFailedDataId(event.getUuid(), outex.getFetchableDataId());
       } catch (CrudlException ex2) {
         LOG.error(formatForLog("Error storing failed data id: %s %s [%s]", uuid, event.getUuid(), outex.getDataId()), ex);
       }

--- a/geoportal-application/geoportal-harvester-war/src/main/resources/config/hrv-beans.xml
+++ b/geoportal-application/geoportal-harvester-war/src/main/resources/config/hrv-beans.xml
@@ -72,6 +72,8 @@
   <bean class="com.esri.geoportal.harvester.dcat.DcatConnector">
     <constructor-arg ref="metaBuilder"/>
   </bean>
+  <bean class="com.esri.geoportal.harvester.thredds.ThreddsConnector"/>
+  
   <!-- Triggers -->
   <bean class="com.esri.geoportal.harvester.engine.triggers.NowTrigger"/>
   <bean class="com.esri.geoportal.harvester.engine.triggers.AtTrigger"/>

--- a/geoportal-commons/geoportal-commons-constants/src/main/java/com/esri/geoportal/commons/constants/MimeType.java
+++ b/geoportal-commons/geoportal-commons-constants/src/main/java/com/esri/geoportal/commons/constants/MimeType.java
@@ -110,6 +110,9 @@ public enum MimeType {
    * @return mime type or default mime type
    */
   public static MimeType parse(String strMimeType, MimeType defaultMimeType) {
+    if (strMimeType!=null) {
+      strMimeType = strMimeType.split(";")[0];
+    }
     for (MimeType mime: values()) {
       if (mime.getName().equals(strMimeType)) {
         return mime;

--- a/geoportal-commons/geoportal-commons-thredds-client/pom.xml
+++ b/geoportal-commons/geoportal-commons-thredds-client/pom.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.esri.geoportal</groupId>
+        <artifactId>geoportal-commons</artifactId>
+        <version>3.6.5-SNAPSHOT</version>
+    </parent>
+    <artifactId>geoportal-commons-thredds-client</artifactId>
+    <name>Esri :: Geoportal Server :: Commons :: THREDDS Client</name>
+    <description>THREDDS Client.</description>
+    <packaging>jar</packaging>
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>commons-utils</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/geoportal-commons/geoportal-commons-thredds-client/src/main/java/com/esri/geoportal/commons/thredds/client/Catalog.java
+++ b/geoportal-commons/geoportal-commons-thredds-client/src/main/java/com/esri/geoportal/commons/thredds/client/Catalog.java
@@ -20,9 +20,9 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Content of the catalog.
+ * Catalog of the catalog.
  */
-public class Content {
+public class Catalog {
     public final URL url;
     public final List<Record> records;
     public final List<URL> folders;
@@ -34,7 +34,7 @@ public class Content {
      * @param records list of record URL's
      * @param folders list of sub-folders URL's
      */
-    public Content(URL url, List<Record> records, List<URL> folders) {
+    public Catalog(URL url, List<Record> records, List<URL> folders) {
         if (url==null) {
           throw new IllegalArgumentException(String.format("Missing url"));
         }

--- a/geoportal-commons/geoportal-commons-thredds-client/src/main/java/com/esri/geoportal/commons/thredds/client/Client.java
+++ b/geoportal-commons/geoportal-commons-thredds-client/src/main/java/com/esri/geoportal/commons/thredds/client/Client.java
@@ -59,7 +59,7 @@ public class Client implements Closeable {
     CloseableHttpClient httpClient = HttpClientBuilder.create().build();
 //    Client client = new Client(httpClient, new URL("https://chlthredds.erdc.dren.mil/thredds/catalog/wis/Atlantic/ST41001/1980/catalog.xml"));
     Client client = new Client(httpClient, new URL("https://data.nodc.noaa.gov/thredds/catalog.xml"));
-    Content content = client.listItems(null);
+    Catalog content = client.readCatalog(null);
     
     System.out.println(content.url);
     System.out.println(content.records);
@@ -78,7 +78,11 @@ public class Client implements Closeable {
     this.url = url;
   }
 
-  public Content listItems(URL url) throws IOException, URISyntaxException, ParserConfigurationException, SAXException, XPathExpressionException {
+  public Catalog readCatalog(URL url) throws IOException, URISyntaxException, ParserConfigurationException, SAXException, XPathExpressionException {
+    if (url==null) {
+      throw new IllegalArgumentException("Missing url");
+    }
+    
     ArrayList<Record> records = new ArrayList<>();
     ArrayList<URL> folders = new ArrayList<>();
 
@@ -114,11 +118,10 @@ public class Client implements Closeable {
       folders.add(catalogUrl);
     }
     
-    
-    return new Content(url, records, folders);
+    return new Catalog(url, records, folders);
   }
 
-  public Document readContent(URL url) throws URISyntaxException, IOException, ParserConfigurationException, SAXException {
+  private Document readContent(URL url) throws URISyntaxException, IOException, ParserConfigurationException, SAXException {
     HttpGet method = new HttpGet(url.toURI());
     try (CloseableHttpResponse httpResponse = httpClient.execute(method); InputStream responseInputStream = httpResponse.getEntity().getContent();) {
       if (httpResponse.getStatusLine().getStatusCode() >= 400) {

--- a/geoportal-commons/geoportal-commons-thredds-client/src/main/java/com/esri/geoportal/commons/thredds/client/Client.java
+++ b/geoportal-commons/geoportal-commons-thredds-client/src/main/java/com/esri/geoportal/commons/thredds/client/Client.java
@@ -46,7 +46,6 @@ import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClientBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
@@ -102,8 +101,8 @@ public class Client implements Closeable {
         if (!urlPath.isEmpty()) {
           URL datasetUrl = new URL(baseUrl, urlPath);
           URIBuilder builder = new URIBuilder(datasetUrl.toURI());
-          URL fetchUrl = builder.addParameter("catalog", this.url.toExternalForm()).addParameter("dataset", ID).build().toURL();
-          records.add(new Record(ID, fetchUrl));
+          URI fetchUrl = builder.addParameter("catalog", this.url.toExternalForm()).addParameter("dataset", ID).build();
+          records.add(new Record(url, ID, fetchUrl));
         }
       }
     }
@@ -119,8 +118,8 @@ public class Client implements Closeable {
     return new Catalog(url, records, folders);
   }
   
-  public Content fetchContent(URL url, String id, Date since) throws URISyntaxException, IOException {
-    HttpGet method = new HttpGet(url.toURI());
+  public Content fetchContent(Record rec, Date since) throws IOException {
+    HttpGet method = new HttpGet(rec.uri);
     method.setConfig(DEFAULT_REQUEST_CONFIG);
     method.setHeader("User-Agent", HttpConstants.getUserAgent());
     
@@ -133,7 +132,7 @@ public class Client implements Closeable {
       boolean readBody = since==null || lastModifiedDate==null || lastModifiedDate.getTime()>=since.getTime();
       byte [] body = readBody? IOUtils.toByteArray(input): null;
       
-      return new Content(id, url, lastModifiedDate, contentType, body);
+      return new Content(rec, lastModifiedDate, contentType, body);
     }
   }
   

--- a/geoportal-commons/geoportal-commons-thredds-client/src/main/java/com/esri/geoportal/commons/thredds/client/Client.java
+++ b/geoportal-commons/geoportal-commons-thredds-client/src/main/java/com/esri/geoportal/commons/thredds/client/Client.java
@@ -15,38 +15,133 @@
  */
 package com.esri.geoportal.commons.thredds.client;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.Closeable;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
+import java.util.ArrayList;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathFactory;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.http.client.HttpResponseException;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
 
 /**
  * THREDDS client.
  */
 public class Client implements Closeable {
+
   private final Logger LOG = LoggerFactory.getLogger(Client.class);
 
   private final CloseableHttpClient httpClient;
   private final URL url;
-  private final ObjectMapper mapper = new ObjectMapper();
 
+//  public static void main(String[] args) throws Exception {
+//    CloseableHttpClient httpClient = HttpClientBuilder.create().build();
+//    Client client = new Client(httpClient, new URL("https://chlthredds.erdc.dren.mil/thredds/catalog/wis/Atlantic/ST41001/1980/catalog.xml"));
+//    Content content = client.listContent(null);
+//    
+//    System.out.println("Ready...");
+//  }
+//
   /**
    * Creates instance of the client.
+   *
    * @param httpClient HTTP client
    * @param url base URL
-   * @param apiKey API key
    */
-  public Client(CloseableHttpClient httpClient, URL url, String apiKey) {
+  public Client(CloseableHttpClient httpClient, URL url) {
     this.httpClient = httpClient;
     this.url = url;
+  }
+
+  public Content listContent(URL url) throws IOException, URISyntaxException, ParserConfigurationException, SAXException, XPathExpressionException {
+    ArrayList<URL> records = new ArrayList<>();
+    ArrayList<URL> folders = new ArrayList<>();
+
+    url = url != null ? url : this.url;
+
+    Document doc = readContent(url);
+
+    XPath xPath = XPathFactory.newInstance().newXPath();
+    Node ndCatalog = (Node)xPath.evaluate("/catalog", doc, XPathConstants.NODE);
     
-    mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-    mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+    String iso = StringUtils.trimToEmpty((String) xPath.evaluate("//service[@serviceType='ISO']/@base", ndCatalog, XPathConstants.STRING));
+    if (!iso.isEmpty()) {
+      // creating TFiles only if iso exist
+      URL baseUrl = new URL(this.url.toExternalForm());
+      baseUrl = new URL(baseUrl, iso);
+    
+      NodeList ndDatasets = (NodeList)xPath.evaluate("//dataset[string-length(normalize-space(@urlPath))>0]", ndCatalog, XPathConstants.NODESET);
+      for (int i=0; i < ndDatasets.getLength(); i++){
+        Node ndDataset = ndDatasets.item(i);
+        String URL = (String)xPath.evaluate("@urlPath",ndDataset,XPathConstants.STRING);
+        String ID = (String)xPath.evaluate("@ID",ndDataset,XPathConstants.STRING);
+        if (!URL.isEmpty()) {
+          URL datasetUrl = new URL(baseUrl, URL);
+          URIBuilder builder = new URIBuilder(datasetUrl.toURI());
+          URL fetchUrl = builder.addParameter("catalog", this.url.toExternalForm()).addParameter("dataset", ID).build().toURL();
+          records.add(fetchUrl);
+        }
+      }
+    }
+    
+    NodeList ndCatalogRefs = (NodeList)xPath.evaluate("//catalogRef/@href", ndCatalog, XPathConstants.NODESET);
+    for (int i=0; i < ndCatalogRefs.getLength(); i++){
+      Node ndCatalogRef = ndCatalogRefs.item(i);
+      String catalogRefUrl = StringUtils.trimToEmpty(ndCatalogRef.getNodeValue());
+      URL catalogUrl = new URL(this.url, catalogRefUrl);
+      folders.add(catalogUrl);
+    }
+    
+    
+    return new Content(url, records, folders);
+  }
+
+  private Document readContent(URL url) throws URISyntaxException, IOException, ParserConfigurationException, SAXException {
+    HttpGet method = new HttpGet(url.toURI());
+    try (CloseableHttpResponse httpResponse = httpClient.execute(method); InputStream responseInputStream = httpResponse.getEntity().getContent();) {
+      if (httpResponse.getStatusLine().getStatusCode() >= 400) {
+        throw new HttpResponseException(httpResponse.getStatusLine().getStatusCode(), httpResponse.getStatusLine().getReasonPhrase());
+      }
+      if (httpResponse.getStatusLine().getStatusCode() == 302) {
+        HttpGet method2 = new HttpGet(URI.create(httpResponse.getFirstHeader("Location").getValue()));
+        try (CloseableHttpResponse httpResponse2 = httpClient.execute(method2); InputStream responseInputStream2 = httpResponse2.getEntity().getContent();) {
+          if (httpResponse2.getStatusLine().getStatusCode() >= 400) {
+            throw new HttpResponseException(httpResponse2.getStatusLine().getStatusCode(), httpResponse2.getStatusLine().getReasonPhrase());
+          }
+          return readContentFromStream(responseInputStream);
+        }
+      } else {
+        return readContentFromStream(responseInputStream);
+      }
+    }
+  }
+
+  private Document readContentFromStream(InputStream stream) throws ParserConfigurationException, SAXException, IOException {
+    DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+    DocumentBuilder builder = factory.newDocumentBuilder();
+    InputSource is = new InputSource(new InputStreamReader(stream, "UTF-8"));
+    return builder.parse(is);
   }
 
   @Override
@@ -55,5 +150,5 @@ public class Client implements Closeable {
       ((Closeable) httpClient).close();
     }
   }
-  
+
 }

--- a/geoportal-commons/geoportal-commons-thredds-client/src/main/java/com/esri/geoportal/commons/thredds/client/Client.java
+++ b/geoportal-commons/geoportal-commons-thredds-client/src/main/java/com/esri/geoportal/commons/thredds/client/Client.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2020 Esri, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.esri.geoportal.commons.thredds.client;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.Closeable;
+import java.io.IOException;
+import java.net.URL;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * THREDDS client.
+ */
+public class Client implements Closeable {
+  private final Logger LOG = LoggerFactory.getLogger(Client.class);
+
+  private final CloseableHttpClient httpClient;
+  private final URL url;
+  private final ObjectMapper mapper = new ObjectMapper();
+
+  /**
+   * Creates instance of the client.
+   * @param httpClient HTTP client
+   * @param url base URL
+   * @param apiKey API key
+   */
+  public Client(CloseableHttpClient httpClient, URL url, String apiKey) {
+    this.httpClient = httpClient;
+    this.url = url;
+    
+    mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+  }
+
+  @Override
+  public void close() throws IOException {
+    if (httpClient instanceof Closeable) {
+      ((Closeable) httpClient).close();
+    }
+  }
+  
+}

--- a/geoportal-commons/geoportal-commons-thredds-client/src/main/java/com/esri/geoportal/commons/thredds/client/Client.java
+++ b/geoportal-commons/geoportal-commons-thredds-client/src/main/java/com/esri/geoportal/commons/thredds/client/Client.java
@@ -55,18 +55,6 @@ public class Client implements Closeable {
   private final CloseableHttpClient httpClient;
   private final URL url;
 
-  public static void main(String[] args) throws Exception {
-    CloseableHttpClient httpClient = HttpClientBuilder.create().build();
-//    Client client = new Client(httpClient, new URL("https://chlthredds.erdc.dren.mil/thredds/catalog/wis/Atlantic/ST41001/1980/catalog.xml"));
-    Client client = new Client(httpClient, new URL("https://data.nodc.noaa.gov/thredds/catalog.xml"));
-    Catalog content = client.readCatalog(null);
-    
-    System.out.println(content.url);
-    System.out.println(content.records);
-    System.out.println(content.folders);
-    System.out.println("Ready...");
-  }
-
   /**
    * Creates instance of the client.
    *

--- a/geoportal-commons/geoportal-commons-thredds-client/src/main/java/com/esri/geoportal/commons/thredds/client/Client.java
+++ b/geoportal-commons/geoportal-commons-thredds-client/src/main/java/com/esri/geoportal/commons/thredds/client/Client.java
@@ -99,6 +99,9 @@ public class Client implements Closeable {
 
         NodeList ndDatasets = (NodeList) xPath.evaluate("//dataset[string-length(normalize-space(@urlPath))>0]", ndCatalog, XPathConstants.NODESET);
         for (int i = 0; i < ndDatasets.getLength(); i++) {
+          if (Thread.currentThread().isInterrupted()) {
+            break;
+          }
           Node ndDataset = ndDatasets.item(i);
           String urlPath = (String) xPath.evaluate("@urlPath", ndDataset, XPathConstants.STRING);
           String ID = (String) xPath.evaluate("@ID", ndDataset, XPathConstants.STRING);
@@ -113,6 +116,9 @@ public class Client implements Closeable {
 
       NodeList ndCatalogRefs = (NodeList) xPath.evaluate("//catalogRef/@href", ndCatalog, XPathConstants.NODESET);
       for (int i = 0; i < ndCatalogRefs.getLength(); i++) {
+        if (Thread.currentThread().isInterrupted()) {
+          break;
+        }
         Node ndCatalogRef = ndCatalogRefs.item(i);
         String catalogRefUrl = StringUtils.trimToEmpty(ndCatalogRef.getNodeValue());
         URL catalogUrl = new URL(this.url, catalogRefUrl);

--- a/geoportal-commons/geoportal-commons-thredds-client/src/main/java/com/esri/geoportal/commons/thredds/client/Content.java
+++ b/geoportal-commons/geoportal-commons-thredds-client/src/main/java/com/esri/geoportal/commons/thredds/client/Content.java
@@ -37,5 +37,9 @@ public class Content {
     this.body = body;
   }
   
+
+  public Content(Record record, Date lastModifiedDate, MimeType contentType) {
+    this(record, lastModifiedDate, contentType, null);
+  }
   
 }

--- a/geoportal-commons/geoportal-commons-thredds-client/src/main/java/com/esri/geoportal/commons/thredds/client/Content.java
+++ b/geoportal-commons/geoportal-commons-thredds-client/src/main/java/com/esri/geoportal/commons/thredds/client/Content.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020 Esri, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.esri.geoportal.commons.thredds.client;
+
+import java.net.URL;
+import java.util.List;
+
+/**
+ * Content of the catalog.
+ */
+public class Content {
+    public final URL url;
+    public final List<URL> records;
+    public final List<URL> folders;
+    
+
+    /**
+     * Creates instance of the content.
+     * @param url starting point
+     * @param records list of record URL's
+     * @param folders list of sub-folders URL's
+     */
+    public Content(URL url, List<URL> records, List<URL> folders) {
+        this.url = url;
+        this.records = records;
+        this.folders = folders;
+    }
+    
+}

--- a/geoportal-commons/geoportal-commons-thredds-client/src/main/java/com/esri/geoportal/commons/thredds/client/Content.java
+++ b/geoportal-commons/geoportal-commons-thredds-client/src/main/java/com/esri/geoportal/commons/thredds/client/Content.java
@@ -16,6 +16,7 @@
 package com.esri.geoportal.commons.thredds.client;
 
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -23,7 +24,7 @@ import java.util.List;
  */
 public class Content {
     public final URL url;
-    public final List<URL> records;
+    public final List<Record> records;
     public final List<URL> folders;
     
 
@@ -33,10 +34,13 @@ public class Content {
      * @param records list of record URL's
      * @param folders list of sub-folders URL's
      */
-    public Content(URL url, List<URL> records, List<URL> folders) {
+    public Content(URL url, List<Record> records, List<URL> folders) {
+        if (url==null) {
+          throw new IllegalArgumentException(String.format("Missing url"));
+        }
         this.url = url;
-        this.records = records;
-        this.folders = folders;
+        this.records = records!=null? records: new ArrayList<>();
+        this.folders = folders!=null? folders: new ArrayList<>();
     }
     
 }

--- a/geoportal-commons/geoportal-commons-thredds-client/src/main/java/com/esri/geoportal/commons/thredds/client/Content.java
+++ b/geoportal-commons/geoportal-commons-thredds-client/src/main/java/com/esri/geoportal/commons/thredds/client/Content.java
@@ -16,28 +16,22 @@
 package com.esri.geoportal.commons.thredds.client;
 
 import com.esri.geoportal.commons.constants.MimeType;
-import java.net.URL;
 import java.util.Date;
 
 /**
  * Content.
  */
 public class Content {
-  public final String id;
-  public final URL url;
+  public final Record record;
   public final Date lastModifiedDate;
   public final MimeType contentType;
   public final byte [] body;
 
-  public Content(String id, URL url, Date lastModifiedDate, MimeType contentType, byte [] body) {
-    if (id==null) {
-      throw new IllegalArgumentException("Missing id");
+  public Content(Record record, Date lastModifiedDate, MimeType contentType, byte [] body) {
+    if (record==null) {
+      throw new IllegalArgumentException("Missing record");
     }
-    if (url==null) {
-      throw new IllegalArgumentException("Missing url");
-    }
-    this.id = id;
-    this.url = url;
+    this.record = record;
     this.lastModifiedDate = lastModifiedDate;
     this.contentType = contentType;
     this.body = body;

--- a/geoportal-commons/geoportal-commons-thredds-client/src/main/java/com/esri/geoportal/commons/thredds/client/Content.java
+++ b/geoportal-commons/geoportal-commons-thredds-client/src/main/java/com/esri/geoportal/commons/thredds/client/Content.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2020 Esri, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.esri.geoportal.commons.thredds.client;
+
+import com.esri.geoportal.commons.constants.MimeType;
+import java.net.URL;
+import java.util.Date;
+
+/**
+ * Content.
+ */
+public class Content {
+  public final String id;
+  public final URL url;
+  public final Date lastModifiedDate;
+  public final MimeType contentType;
+  public final byte [] body;
+
+  public Content(String id, URL url, Date lastModifiedDate, MimeType contentType, byte [] body) {
+    if (id==null) {
+      throw new IllegalArgumentException("Missing id");
+    }
+    if (url==null) {
+      throw new IllegalArgumentException("Missing url");
+    }
+    this.id = id;
+    this.url = url;
+    this.lastModifiedDate = lastModifiedDate;
+    this.contentType = contentType;
+    this.body = body;
+  }
+  
+  
+}

--- a/geoportal-commons/geoportal-commons-thredds-client/src/main/java/com/esri/geoportal/commons/thredds/client/ContentData.java
+++ b/geoportal-commons/geoportal-commons-thredds-client/src/main/java/com/esri/geoportal/commons/thredds/client/ContentData.java
@@ -19,25 +19,21 @@ import com.esri.geoportal.commons.constants.MimeType;
 import java.util.Date;
 
 /**
- * Content.
+ * Content data.
  */
-public class Content extends ContentData {
-  public final Record record;
+public class ContentData {
+  public final Date lastModifiedDate;
+  public final MimeType contentType;
+  public final byte [] body;
 
-  public Content(Record record, Date lastModifiedDate, MimeType contentType, byte [] body) {
-    super(lastModifiedDate, contentType, body);
-    if (record==null) {
-      throw new IllegalArgumentException("Missing record");
-    }
-    this.record = record;
+  public ContentData(Date lastModifiedDate, MimeType contentType, byte [] body) {
+    this.lastModifiedDate = lastModifiedDate;
+    this.contentType = contentType;
+    this.body = body;
   }
 
-  public Content(Record record, Date lastModifiedDate, MimeType contentType) {
-    this(record, lastModifiedDate, contentType, null);
-  }
-
-  public Content(Record record, ContentData contentData) {
-    this(record, contentData.lastModifiedDate, contentData.contentType, contentData.body);
+  public ContentData(Date lastModifiedDate, MimeType contentType) {
+    this(lastModifiedDate, contentType, null);
   }
   
 }

--- a/geoportal-commons/geoportal-commons-thredds-client/src/main/java/com/esri/geoportal/commons/thredds/client/Record.java
+++ b/geoportal-commons/geoportal-commons-thredds-client/src/main/java/com/esri/geoportal/commons/thredds/client/Record.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 Esri, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.esri.geoportal.commons.thredds.client;
+
+import java.net.URL;
+
+/**
+ * Record
+ */
+public class Record {
+  public final String id;
+  public final URL url;
+
+  /**
+   * Creates instance of the record.
+   * @param id id
+   * @param url url
+   */
+  public Record(String id, URL url) {
+    if (id==null) {
+      throw new IllegalArgumentException("Empty id");
+    }
+    if (url==null) {
+      throw new IllegalArgumentException("Empty url");
+    }
+    this.id = id;
+    this.url = url;
+  }
+  
+  
+}

--- a/geoportal-commons/geoportal-commons-thredds-client/src/main/java/com/esri/geoportal/commons/thredds/client/Record.java
+++ b/geoportal-commons/geoportal-commons-thredds-client/src/main/java/com/esri/geoportal/commons/thredds/client/Record.java
@@ -15,29 +15,35 @@
  */
 package com.esri.geoportal.commons.thredds.client;
 
+import java.net.URI;
 import java.net.URL;
 
 /**
  * Record
  */
 public class Record {
+  public final URL catalog;
   public final String id;
-  public final URL url;
+  public final URI uri;
 
   /**
    * Creates instance of the record.
    * @param id id
-   * @param url url
+   * @param url uri
    */
-  public Record(String id, URL url) {
+  public Record(URL catalog, String id, URI uri) {
+    if (catalog==null) {
+      throw new IllegalArgumentException("Empty catalog");
+    }
     if (id==null) {
       throw new IllegalArgumentException("Empty id");
     }
-    if (url==null) {
-      throw new IllegalArgumentException("Empty url");
+    if (uri==null) {
+      throw new IllegalArgumentException("Empty uri");
     }
+    this.catalog = catalog;
     this.id = id;
-    this.url = url;
+    this.uri = uri;
   }
   
   

--- a/geoportal-commons/geoportal-commons-thredds-client/src/main/java/com/esri/geoportal/commons/thredds/client/package-info.java
+++ b/geoportal-commons/geoportal-commons-thredds-client/src/main/java/com/esri/geoportal/commons/thredds/client/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2016 Esri, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * THREDDS client.
+ */
+package com.esri.geoportal.commons.thredds.client;

--- a/geoportal-commons/pom.xml
+++ b/geoportal-commons/pom.xml
@@ -25,5 +25,6 @@
     <module>geoportal-commons-oai-client</module>
     <module>geoportal-commons-doc</module>
     <module>geoportal-commons-dcat-client</module>
+    <module>geoportal-commons-thredds-client</module>
   </modules>
 </project>

--- a/geoportal-connectors/geoportal-harvester-agp-publisher/src/main/java/com/esri/geoportal/harvester/agp/AgpOutputBroker.java
+++ b/geoportal-connectors/geoportal-harvester-agp-publisher/src/main/java/com/esri/geoportal/harvester/agp/AgpOutputBroker.java
@@ -141,7 +141,7 @@ import org.xml.sax.SAXException;
       MapAttribute attributes = extractMapAttributes(ref, content);
 
       if (attributes == null) {
-        throw new DataOutputException(this, ref.getId(), String.format("Error extracting attributes from data."));
+        throw new DataOutputException(this, ref, String.format("Error extracting attributes from data."));
       }
 
       // build typeKeywords array
@@ -235,7 +235,7 @@ import org.xml.sax.SAXException;
 
           if (response == null || !response.success) {
             String error = response != null && response.error != null && response.error.message != null ? response.error.message : null;
-            throw new DataOutputException(this, ref.getId(), String.format("Error adding item: %s%s", ref, error != null ? "; " + error : ""));
+            throw new DataOutputException(this, ref, String.format("Error adding item: %s%s", ref, error != null ? "; " + error : ""));
           }
 
           client.share(definition.getCredentials().getUserName(), definition.getFolderId(), response.id, true, true, null, token);
@@ -246,7 +246,7 @@ import org.xml.sax.SAXException;
 
           itemEntry = client.readItem(itemEntry.id, token);
           if (itemEntry == null) {
-            throw new DataOutputException(this, ref.getId(), String.format("Unable to read item entry."));
+            throw new DataOutputException(this, ref, String.format("Unable to read item entry."));
           }
 
           // update item if does exist
@@ -266,7 +266,7 @@ import org.xml.sax.SAXException;
 
           if (response == null || !response.success) {
             String error = response != null && response.error != null && response.error.message != null ? response.error.message : null;
-            throw new DataOutputException(this, ref.getId(), String.format("Error adding item: %s%s", ref, error != null ? "; " + error : ""));
+            throw new DataOutputException(this, ref, String.format("Error adding item: %s%s", ref, error != null ? "; " + error : ""));
           }
 
           existing.remove(itemEntry.id);
@@ -280,7 +280,7 @@ import org.xml.sax.SAXException;
       }
 
     } catch (MetaException | IOException | ParserConfigurationException | SAXException | URISyntaxException ex) {
-      throw new DataOutputException(this, ref.getId(), String.format("Error publishing data: %s", ref), ex);
+      throw new DataOutputException(this, ref, String.format("Error publishing data: %s", ref), ex);
     } finally {
       if (fileToUpload!=null && deleteTempFile) {
         fileToUpload.delete();

--- a/geoportal-connectors/geoportal-harvester-console/src/main/java/com/esri/geoportal/harvester/console/ConsoleBroker.java
+++ b/geoportal-connectors/geoportal-harvester-console/src/main/java/com/esri/geoportal/harvester/console/ConsoleBroker.java
@@ -72,7 +72,7 @@ import java.io.IOException;
       
       return PublishingStatus.CREATED;
     } catch (IOException ex) {
-      throw new DataOutputException(this, ref.getId(), String.format("Error publishing data: %s", ref), ex);
+      throw new DataOutputException(this, ref, String.format("Error publishing data: %s", ref), ex);
     }
   }
 

--- a/geoportal-connectors/geoportal-harvester-folder-big/src/main/java/com/esri/geoportal/harvester/folderbig/FolderBroker.java
+++ b/geoportal-connectors/geoportal-harvester-folder-big/src/main/java/com/esri/geoportal/harvester/folderbig/FolderBroker.java
@@ -150,7 +150,7 @@ import static com.esri.geoportal.harvester.folderbig.PathUtil.splitPath;
             existing.remove(f.toRealPath().toString());
             //return created ? PublishingStatus.CREATED : PublishingStatus.UPDATED;
           } catch (Exception ex) {
-            throw new DataOutputException(this, String.format("Error publishing data: %s", ref), ex.getMessage());
+            throw new DataOutputException(this, ref, ex.getMessage());
 
           }
         }
@@ -158,9 +158,9 @@ import static com.esri.geoportal.harvester.folderbig.PathUtil.splitPath;
         return PublishingStatus.CREATED;
 
     } catch (IOException ex) {
-      throw new DataOutputException(this, String.format("Error publishing data: %s", ref),  ex.getMessage());
+      throw new DataOutputException(this, ref, ex.getMessage());
     }  catch (Exception ex) {
-    throw new DataOutputException(this, String.format("Error publishing data: %s", ref),  ex.getMessage());
+    throw new DataOutputException(this, ref, ex.getMessage());
   }
   }
 

--- a/geoportal-connectors/geoportal-harvester-folder-big/src/main/java/com/esri/geoportal/harvester/folderbig/FolderBroker.java
+++ b/geoportal-connectors/geoportal-harvester-folder-big/src/main/java/com/esri/geoportal/harvester/folderbig/FolderBroker.java
@@ -197,7 +197,7 @@ import static com.esri.geoportal.harvester.folderbig.PathUtil.splitPath;
 
       }
       folderName =Paths.get(folderName.toString(), subFolder.get(subFolder.size() - 1));
-      if (!folderName.getFileName().toString().contains(".")) {
+      if (!folderName.getFileName().toString().endsWith(extension)) {
         folderName = folderName.getParent().resolve(folderName.getFileName() + "." + extension);
       }
     } else {

--- a/geoportal-connectors/geoportal-harvester-folder/src/main/java/com/esri/geoportal/harvester/folder/FolderBroker.java
+++ b/geoportal-connectors/geoportal-harvester-folder/src/main/java/com/esri/geoportal/harvester/folder/FolderBroker.java
@@ -141,14 +141,14 @@ import org.slf4j.LoggerFactory;
             //return created ? PublishingStatus.CREATED : PublishingStatus.UPDATED;
           } catch (Exception ex) {
             if (!Thread.currentThread().isInterrupted()) {
-              throw new DataOutputException(this, ref.getId(), String.format("Error publishing data: %s", ref), ex);
+              throw new DataOutputException(this, ref, String.format("Error publishing data: %s", ref), ex);
             }
           }
         }
       }
       return PublishingStatus.CREATED;
     } catch (IOException ex) {
-      throw new DataOutputException(this, ref.getId(), String.format("Error publishing data: %s", ref), ex);
+      throw new DataOutputException(this, ref, String.format("Error publishing data: %s", ref), ex);
     }
   }
 

--- a/geoportal-connectors/geoportal-harvester-folder/src/main/java/com/esri/geoportal/harvester/folder/FolderBroker.java
+++ b/geoportal-connectors/geoportal-harvester-folder/src/main/java/com/esri/geoportal/harvester/folder/FolderBroker.java
@@ -180,7 +180,7 @@ import org.slf4j.LoggerFactory;
       for (String sf : subFolder) {
         fileName = Paths.get(fileName.toString(), sf);
       }
-      if (!fileName.getFileName().toString().contains(".")) {
+      if (!fileName.getFileName().toString().endsWith(extension)) {
         fileName = fileName.getParent().resolve(fileName.getFileName() + "." + extension);
       }
     } else {

--- a/geoportal-connectors/geoportal-harvester-gpt/src/main/java/com/esri/geoportal/harvester/gpt/GptBroker.java
+++ b/geoportal-connectors/geoportal-harvester-gpt/src/main/java/com/esri/geoportal/harvester/gpt/GptBroker.java
@@ -199,10 +199,10 @@ import java.util.stream.Collectors;
 
       PublishResponse response = client.publish(data, ref.getAttributesMap(), uuid, xml, json, definition.getForceAdd());
       if (response == null) {
-        throw new DataOutputException(this, ref.getId(), "No response received");
+        throw new DataOutputException(this, ref, "No response received");
       }
       if (response.getError() != null) {
-        throw new DataOutputException(this, ref.getId(), response.getError().getMessage()) {
+        throw new DataOutputException(this, ref, response.getError().getMessage()) {
           @Override
           public boolean isNegligible() {
             return true;
@@ -212,7 +212,7 @@ import java.util.stream.Collectors;
       existing.remove(response.getId());
       return response.getStatus().equalsIgnoreCase("created") ? PublishingStatus.CREATED : PublishingStatus.UPDATED;
     } catch (IOException | URISyntaxException ex) {
-      throw new DataOutputException(this, ref.getId(), String.format("Error publishing data: %s", ref), ex);
+      throw new DataOutputException(this, ref, String.format("Error publishing data: %s", ref), ex);
     }
   }
 

--- a/geoportal-connectors/geoportal-harvester-thredds/pom.xml
+++ b/geoportal-connectors/geoportal-harvester-thredds/pom.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.esri.geoportal</groupId>
+        <artifactId>geoportal-connectors</artifactId>
+        <version>3.6.5-SNAPSHOT</version>
+    </parent>
+    <artifactId>geoportal-harvester-thredds</artifactId>
+    <packaging>jar</packaging>
+    <name>Esri :: Geoportal Server :: Harvester :: Data Source :: THREDDS</name>
+    <description>Inbound adaptor capable of harvesting data from THREDDS end point.</description>
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>harvester-api-base</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>geoportal-commons-thredds-client</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/geoportal-connectors/geoportal-harvester-thredds/src/main/java/com/esri/geoportal/harvester/thredds/ThreddsBroker.java
+++ b/geoportal-connectors/geoportal-harvester-thredds/src/main/java/com/esri/geoportal/harvester/thredds/ThreddsBroker.java
@@ -174,7 +174,7 @@ import java.util.stream.Collectors;
     
     private List<URL> selectFolders(List<URL> fld) {
       fld.stream().filter(url -> visitedFolders.contains(url)).forEach(url -> {
-        LOG.info(String.format("Skipping duplicated sub-catalog: %s", url));
+        LOG.debug(String.format("Skipping duplicated sub-catalog: %s", url));
       });
       fld = fld.stream().filter(url -> !visitedFolders.contains(url)).collect(Collectors.toList());
       visitedFolders.addAll(fld);

--- a/geoportal-connectors/geoportal-harvester-thredds/src/main/java/com/esri/geoportal/harvester/thredds/ThreddsBroker.java
+++ b/geoportal-connectors/geoportal-harvester-thredds/src/main/java/com/esri/geoportal/harvester/thredds/ThreddsBroker.java
@@ -207,6 +207,7 @@ import java.util.stream.Collectors;
         ThreddsBroker.this.td.getSource().getRef(), 
         ThreddsBroker.this.td.getRef()
       );
+      ref.addContext(nextContent.contentType, nextContent.body);
       nextContent = null;
       return ref;
     }

--- a/geoportal-connectors/geoportal-harvester-thredds/src/main/java/com/esri/geoportal/harvester/thredds/ThreddsBroker.java
+++ b/geoportal-connectors/geoportal-harvester-thredds/src/main/java/com/esri/geoportal/harvester/thredds/ThreddsBroker.java
@@ -174,7 +174,7 @@ import java.util.stream.Collectors;
     
     private List<URL> selectFolders(List<URL> fld) {
       fld.stream().filter(url -> visitedFolders.contains(url)).forEach(url -> {
-        LOG.debug(String.format("Skipping duplicated sub-catalog: %s", url));
+        LOG.info(String.format("Skipping duplicated sub-catalog: %s", url));
       });
       fld = fld.stream().filter(url -> !visitedFolders.contains(url)).collect(Collectors.toList());
       visitedFolders.addAll(fld);
@@ -183,11 +183,13 @@ import java.util.stream.Collectors;
     
     private Content readContent(Record rec) {
         try {
-          Content content = client.fetchContent(rec, iteratorContext.getLastHarvestDate());
+          Content content = client.fetchContent(rec, preDownload -> iteratorContext.getLastHarvestDate() == null || preDownload.lastModifiedDate == null || preDownload.lastModifiedDate.getTime() >= iteratorContext.getLastHarvestDate().getTime());
           if (content!=null && content.body!=null) {
             return content;
           }
-        } catch (IOException ignore) {} 
+        } catch (IOException ignore) {
+          LOG.debug(String.format("Error reading record %s (%s)", rec.id, rec.uri), ignore);
+        } 
         return null;
     }
     

--- a/geoportal-connectors/geoportal-harvester-thredds/src/main/java/com/esri/geoportal/harvester/thredds/ThreddsBroker.java
+++ b/geoportal-connectors/geoportal-harvester-thredds/src/main/java/com/esri/geoportal/harvester/thredds/ThreddsBroker.java
@@ -157,30 +157,30 @@ import org.xml.sax.SAXException;
       try {
         if (folders == null) {
           Catalog content = client.readCatalog(definition.getHostUrl());
+          
           folders = new LinkedList<>(selectFolders(content.folders));
           recIter = content.records.iterator();
-
-          return hasNext();
         }
 
-        if (recIter == null || !recIter.hasNext()) {
-          if (folders == null || folders.isEmpty()) {
+        while (!recIter.hasNext()) {
+          if (folders.isEmpty()) {
             return false;
           }
 
           Catalog content = client.readCatalog(folders.pollFirst());
+          
           folders.addAll(selectFolders(content.folders));
           recIter = content.records.iterator();
-
-          return hasNext();
         }
 
-        nextContent = readContent(recIter.next());
-        if (nextContent == null) {
-          return hasNext();
-        }
+        do {
+          nextContent = readContent(recIter.next());
+          if (nextContent!=null) {
+            return true;
+          }
+        } while (recIter.hasNext());
 
-        return true;
+        return hasNext();
       } catch (DataInputException | URISyntaxException | ParserConfigurationException | XPathExpressionException | SAXException ex) {
         throw new DataInputException(ThreddsBroker.this, String.format("Error retrieving content."), ex);
       }

--- a/geoportal-connectors/geoportal-harvester-thredds/src/main/java/com/esri/geoportal/harvester/thredds/ThreddsBroker.java
+++ b/geoportal-connectors/geoportal-harvester-thredds/src/main/java/com/esri/geoportal/harvester/thredds/ThreddsBroker.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright 2020 Esri, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.esri.geoportal.harvester.thredds;
+
+import com.esri.geoportal.commons.constants.ItemType;
+import com.esri.geoportal.commons.constants.MimeType;
+import com.esri.geoportal.commons.constants.MimeTypeUtils;
+import com.esri.geoportal.commons.http.BotsHttpClient;
+import com.esri.geoportal.commons.robots.Bots;
+import com.esri.geoportal.commons.robots.BotsUtils;
+import com.esri.geoportal.commons.utils.SimpleCredentials;
+import com.esri.geoportal.harvester.api.defs.EntityDefinition;
+import com.esri.geoportal.harvester.api.ex.DataInputException;
+import com.esri.geoportal.harvester.api.ex.DataProcessorException;
+import com.esri.geoportal.harvester.api.specs.InputBroker;
+import com.esri.geoportal.harvester.api.specs.InputConnector;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import com.esri.geoportal.harvester.api.DataContent;
+import com.esri.geoportal.harvester.api.DataReference;
+import com.esri.geoportal.harvester.api.defs.TaskDefinition;
+import java.io.InputStream;
+import java.util.ArrayList;
+
+/**
+ * THREDDS broker.
+ */
+/*package*/ class ThreddsBroker implements InputBroker {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ThreddsBroker.class);
+
+  private final ThreddsConnector connector;
+  private final ThreddsBrokerDefinitionAdaptor definition;
+  private final ArrayList<ThreddsIter> iterators = new ArrayList<>();
+
+  protected CloseableHttpClient httpClient;
+  protected TaskDefinition td;
+
+  private static final ObjectMapper mapper = new ObjectMapper();
+
+  static {
+    mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    mapper.configure(JsonParser.Feature.ALLOW_NON_NUMERIC_NUMBERS, true);
+    mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+  }
+
+  /**
+   * Creates instance of the broker.
+   *
+   * @param connector connector
+   * @param definition definition
+   */
+  public ThreddsBroker(ThreddsConnector connector, ThreddsBrokerDefinitionAdaptor definition) {
+    this.connector = connector;
+    this.definition = definition;
+  }
+
+  @Override
+  public void initialize(InitContext context) throws DataProcessorException {
+    definition.override(context.getParams());
+    td = context.getTask().getTaskDefinition();
+    CloseableHttpClient http = HttpClientBuilder.create().useSystemProperties().build();
+    if (context.getTask().getTaskDefinition().isIgnoreRobotsTxt()) {
+      httpClient = http;
+    } else {
+      Bots bots = BotsUtils.readBots(definition.getBotsConfig(), http, definition.getHostUrl());
+      httpClient = new BotsHttpClient(http, bots);
+    }
+  }
+
+  @Override
+  public void terminate() {
+    new ArrayList<>(iterators).forEach(ThreddsIter::close);
+
+    if (httpClient != null) {
+      try {
+        httpClient.close();
+      } catch (IOException ex) {
+        LOG.error(String.format("Error terminating broker."), ex);
+      }
+    }
+  }
+
+  @Override
+  public URI getBrokerUri() throws URISyntaxException {
+    return new URI("THREDDS", definition.getHostUrl().toExternalForm(), null);
+  }
+
+  @Override
+  public Iterator iterator(IteratorContext iteratorContext) throws DataInputException {
+    ThreddsIter iter = new ThreddsIter(null) {
+      @Override
+      protected void onClose() {
+        iterators.remove(this);
+      }
+    };
+
+    iterators.add(iter);
+    return iter;
+  }
+
+  private class ThreddsIter implements InputBroker.Iterator {
+    private final InputStream input;
+
+
+    public ThreddsIter(InputStream input) {
+        this.input = input;
+    }
+
+    @Override
+    public boolean hasNext() throws DataInputException {
+        return false;
+    }
+
+    @Override
+    public DataReference next() throws DataInputException {
+        return null;
+    }
+
+    protected void onClose() {
+      // called upon closing iterator
+    }
+
+    private void close() {
+      if (input != null) {
+        try {
+          input.close();
+        } catch (IOException ex) {
+          LOG.debug("Error closing THREDDS iterator.", ex);
+        }
+      }
+      onClose();
+    }
+  }
+
+  @Override
+  public boolean hasAccess(SimpleCredentials creds) {
+    return true;
+  }
+
+  @Override
+  public String toString() {
+    return String.format("THREDDS [%s]", definition.getHostUrl());
+  }
+
+  @Override
+  public InputConnector getConnector() {
+    return connector;
+  }
+
+  @Override
+  public EntityDefinition getEntityDefinition() {
+    return definition.getEntityDefinition();
+  }
+
+  @Override
+  public DataContent readContent(String id) throws DataInputException {
+    // TODO: provide THREDDS iterator implementation
+    return null;
+  }
+
+  private String generateSchemeName(String url) {
+    String serviceType = url != null ? ItemType.matchPattern(url).stream()
+            .filter(it -> it.getServiceType() != null)
+            .map(ItemType::getServiceType)
+            .findFirst().orElse(null) : null;
+    if (serviceType != null) {
+      return "urn:x-esri:specification:ServiceType:ArcGIS:" + serviceType;
+    }
+    if (url != null) {
+      int idx = url.lastIndexOf(".");
+      if (idx >= 0) {
+        String ext = url.substring(idx + 1);
+        MimeType mimeType = MimeTypeUtils.mapExtension(ext);
+        return generateSchemeName(mimeType);
+      }
+    }
+    return null;
+  }
+
+  private String generateSchemeName(MimeType mimeType) {
+    return mimeType != null ? "urn:" + mimeType.getName() : null;
+  }
+}

--- a/geoportal-connectors/geoportal-harvester-thredds/src/main/java/com/esri/geoportal/harvester/thredds/ThreddsBroker.java
+++ b/geoportal-connectors/geoportal-harvester-thredds/src/main/java/com/esri/geoportal/harvester/thredds/ThreddsBroker.java
@@ -163,6 +163,9 @@ import org.xml.sax.SAXException;
         }
 
         while (!recIter.hasNext()) {
+          if (Thread.currentThread().isInterrupted()) {
+            return false;
+          }
           if (folders.isEmpty()) {
             return false;
           }
@@ -174,6 +177,9 @@ import org.xml.sax.SAXException;
         }
 
         do {
+          if (Thread.currentThread().isInterrupted()) {
+            return false;
+          }
           nextContent = readContent(recIter.next());
           if (nextContent!=null) {
             return true;

--- a/geoportal-connectors/geoportal-harvester-thredds/src/main/java/com/esri/geoportal/harvester/thredds/ThreddsBroker.java
+++ b/geoportal-connectors/geoportal-harvester-thredds/src/main/java/com/esri/geoportal/harvester/thredds/ThreddsBroker.java
@@ -148,7 +148,7 @@ import org.apache.http.client.methods.HttpGet;
       try {
         if (folders==null) {
           Catalog content = client.readCatalog(definition.getHostUrl());
-          folders.addAll(content.folders);
+          folders = new LinkedList<>(content.folders);
           recordsIter = content.records.iterator();
           
           return hasNext();

--- a/geoportal-connectors/geoportal-harvester-thredds/src/main/java/com/esri/geoportal/harvester/thredds/ThreddsBrokerDefinitionAdaptor.java
+++ b/geoportal-connectors/geoportal-harvester-thredds/src/main/java/com/esri/geoportal/harvester/thredds/ThreddsBrokerDefinitionAdaptor.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2016 Esri, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.esri.geoportal.harvester.thredds;
+
+import static com.esri.geoportal.harvester.thredds.ThreddsConstants.*;
+import com.esri.geoportal.commons.robots.BotsConfig;
+import com.esri.geoportal.harvester.api.base.BotsBrokerDefinitionAdaptor;
+import com.esri.geoportal.harvester.api.base.BrokerDefinitionAdaptor;
+import com.esri.geoportal.harvester.api.defs.EntityDefinition;
+import com.esri.geoportal.harvester.api.ex.InvalidDefinitionException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Map;
+import org.apache.commons.lang3.BooleanUtils;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * THREDDS broker definition adaptor.
+ */
+public class ThreddsBrokerDefinitionAdaptor extends BrokerDefinitionAdaptor {
+  
+  private final BotsBrokerDefinitionAdaptor botsAdaptor;
+  private URL hostUrl;
+  private boolean emitXml = true;
+  private boolean emitJson = false;
+
+
+  /**
+   * Creates instance of the adaptor.
+   * @param def broker definition
+   * @throws InvalidDefinitionException if definition is invalid
+   * @throws IllegalArgumentException if invalid broker definition
+   */
+  public ThreddsBrokerDefinitionAdaptor(EntityDefinition def) throws InvalidDefinitionException {
+    super(def);
+    this.botsAdaptor = new BotsBrokerDefinitionAdaptor(def);
+    if (StringUtils.trimToEmpty(def.getType()).isEmpty()) {
+      def.setType(ThreddsConnector.TYPE);
+    } else if (!getType().equals(def.getType())) {
+      throw new InvalidDefinitionException("Broker definition doesn't match");
+    } else {
+      initialize(def);
+    }
+  }
+
+  protected String getType() {
+    return ThreddsConnector.TYPE;
+  }
+  
+  /**
+   * Initializes adaptor from definition.
+   * @param def broker definition
+   * @throws InvalidDefinitionException if definition is invalid
+   */
+  protected void initialize(EntityDefinition def) throws InvalidDefinitionException {
+    emitXml = BooleanUtils.toBooleanDefaultIfNull(BooleanUtils.toBooleanObject(get(P_EMIT_XML)), true);
+    emitJson = BooleanUtils.toBooleanDefaultIfNull(BooleanUtils.toBooleanObject(get(P_EMIT_JSON)), false);
+    
+    try {
+      hostUrl = new URL(get(P_HOST_URL));
+    } catch (MalformedURLException ex) {
+      throw new InvalidDefinitionException(String.format("Invalid %s: %s", P_HOST_URL,get(P_HOST_URL)), ex);
+    }
+  }
+
+  @Override
+  public void override(Map<String, String> params) {
+    consume(params,P_HOST_URL);
+    consume(params,P_EMIT_XML);
+    consume(params,P_EMIT_JSON);
+    botsAdaptor.override(params);
+  }
+  
+  public URL getHostUrl() {
+    return hostUrl;
+  }
+
+  public void setHostUrl(URL hostUrl) {
+    this.hostUrl = hostUrl;
+    set(P_HOST_URL,hostUrl.toExternalForm());
+  }
+
+  /**
+   * Gets bots config.
+   * @return bots config
+   */
+  public BotsConfig getBotsConfig() {
+    return botsAdaptor.getBotsConfig();
+  }
+
+  /**
+   * Sets bots config.
+   * @param botsConfig bots config 
+   */
+  public void setBotsConfig(BotsConfig botsConfig) {
+    botsAdaptor.setBotsConfig(botsConfig);
+  }
+
+  public boolean getEmitXml() {
+    return emitXml;
+  }
+
+  public void setEmitXml(boolean emitXml) {
+    this.emitXml = emitXml;
+    set(P_EMIT_XML, BooleanUtils.toStringTrueFalse(emitXml));
+  }
+
+  public boolean getEmitJson() {
+    return emitJson;
+  }
+
+  public void setEmitJson(boolean emitJson) {
+    this.emitJson = emitJson;
+    set(P_EMIT_JSON, BooleanUtils.toStringTrueFalse(emitJson));
+  }
+  
+}

--- a/geoportal-connectors/geoportal-harvester-thredds/src/main/java/com/esri/geoportal/harvester/thredds/ThreddsConnector.java
+++ b/geoportal-connectors/geoportal-harvester-thredds/src/main/java/com/esri/geoportal/harvester/thredds/ThreddsConnector.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2020 Esri, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.esri.geoportal.harvester.thredds;
+
+import static com.esri.geoportal.harvester.thredds.ThreddsConstants.*;
+import com.esri.geoportal.harvester.api.defs.EntityDefinition;
+import com.esri.geoportal.harvester.api.defs.UITemplate;
+import com.esri.geoportal.harvester.api.ex.InvalidDefinitionException;
+import com.esri.geoportal.harvester.api.specs.InputBroker;
+import com.esri.geoportal.harvester.api.specs.InputConnector;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.ResourceBundle;
+
+/**
+ * THREDDS connector.
+ */
+public class ThreddsConnector implements InputConnector<InputBroker> {
+
+  public static final String TYPE = "THREDDS";
+
+  /**
+   * Creates instance of the connector.
+   */
+  public ThreddsConnector() {
+  }
+
+  @Override
+  public String getType() {
+    return TYPE;
+  }
+
+  @Override
+  public UITemplate getTemplate(Locale locale) {
+    ResourceBundle bundle = ResourceBundle.getBundle("ThreddsResource", locale);
+    List<UITemplate.Argument> args = new ArrayList<>();
+    args.add(new UITemplate.StringArgument(P_HOST_URL, bundle.getString("thredds.url"), true){
+      @Override
+      public String getHint() {
+        return bundle.getString("thredds.hint");
+      }
+    });
+    args.add(new UITemplate.BooleanArgument(P_EMIT_XML, bundle.getString("thredds.emit.xml"),false, Boolean.TRUE));
+    args.add(new UITemplate.BooleanArgument(P_EMIT_JSON, bundle.getString("thredds.emit.json"),false, Boolean.TRUE));
+    return new UITemplate(getType(), bundle.getString("thredds"), args);
+  }
+
+  @Override
+  public void validateDefinition(EntityDefinition definition) throws InvalidDefinitionException {
+    new ThreddsBrokerDefinitionAdaptor(definition);
+  }
+
+  @Override
+  public InputBroker createBroker(EntityDefinition definition) throws InvalidDefinitionException {
+    return new ThreddsBroker(this, new ThreddsBrokerDefinitionAdaptor(definition));
+  }
+}

--- a/geoportal-connectors/geoportal-harvester-thredds/src/main/java/com/esri/geoportal/harvester/thredds/ThreddsConnector.java
+++ b/geoportal-connectors/geoportal-harvester-thredds/src/main/java/com/esri/geoportal/harvester/thredds/ThreddsConnector.java
@@ -55,7 +55,7 @@ public class ThreddsConnector implements InputConnector<InputBroker> {
       }
     });
     args.add(new UITemplate.BooleanArgument(P_EMIT_XML, bundle.getString("thredds.emit.xml"),false, Boolean.TRUE));
-    args.add(new UITemplate.BooleanArgument(P_EMIT_JSON, bundle.getString("thredds.emit.json"),false, Boolean.TRUE));
+    args.add(new UITemplate.BooleanArgument(P_EMIT_JSON, bundle.getString("thredds.emit.json"),false, Boolean.FALSE));
     return new UITemplate(getType(), bundle.getString("thredds"), args);
   }
 

--- a/geoportal-connectors/geoportal-harvester-thredds/src/main/java/com/esri/geoportal/harvester/thredds/ThreddsConstants.java
+++ b/geoportal-connectors/geoportal-harvester-thredds/src/main/java/com/esri/geoportal/harvester/thredds/ThreddsConstants.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2020 Esri, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.esri.geoportal.harvester.thredds;
+
+/**
+ * THREDDS constants.
+ */
+/*package*/ class ThreddsConstants {
+  public static final String P_HOST_URL  = "thredds-host-url";
+  public static final String P_EMIT_XML  = "thredds-emit-xml";
+  public static final String P_EMIT_JSON = "thredds-emit-json";
+}

--- a/geoportal-connectors/geoportal-harvester-thredds/src/main/java/com/esri/geoportal/harvester/thredds/package-info.java
+++ b/geoportal-connectors/geoportal-harvester-thredds/src/main/java/com/esri/geoportal/harvester/thredds/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2020 Esri, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * THREDDS data source.
+ */
+package com.esri.geoportal.harvester.thredds;

--- a/geoportal-connectors/geoportal-harvester-thredds/src/main/resources/ThreddsResource.properties
+++ b/geoportal-connectors/geoportal-harvester-thredds/src/main/resources/ThreddsResource.properties
@@ -1,0 +1,19 @@
+# Copyright 2020 Esri, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+thredds = THREDDS
+thredds.url = URL
+thredds.hint = http://server:port/<catalog.xml>
+thredds.emit.xml = Emit XML
+thredds.emit.json = Emit JSON

--- a/geoportal-connectors/pom.xml
+++ b/geoportal-connectors/pom.xml
@@ -28,5 +28,6 @@
         <module>geoportal-harvester-folder-big</module>
         <module>geoportal-harvester-jdbc</module>
         <module>geoportal-harvester-dcat</module>
+        <module>geoportal-harvester-thredds</module>
     </modules>
 </project>


### PR DESCRIPTION
## Input broker for THREDDS protocol. 

### Tested with the following catalogs:

1. [NOAA NODC (https://data.nodc.noaa.gov/thredds/catalog.xml)](https://data.nodc.noaa.gov/thredds/catalog.xml),
2. [OCEANWATCH (https://oce)anwatch.pfeg.noaa.gov/thredds/catalog.xml](https://oceanwatch.pfeg.noaa.gov/thredds/catalog.xml),
3. [WHOI (https://geoport.whoi.edu/thredds/catalog.xml)](https://geoport.whoi.edu/thredds/catalog.xml),
4. [https://cida.usgs.gov/thredds/catalog.xml](https://cida.usgs.gov/thredds/catalog.xml),
5. [https://hfrnet-tds.ucsd.edu/thredds/catalog.xml](https://hfrnet-tds.ucsd.edu/thredds/catalog.xml),
6. [https://thredds.ucar.edu/thredds/catalog.xml](https://thredds.ucar.edu/thredds/catalog.xml)

### Notes:
1. Some of the metadata fail validation but THREDDS broker itself is working as designed,
2. Some older known THREDDS catalogs appear to be no longer in service,
3. Catalog of interest at `https://chlthredds.erdc.dren.mil/thredds/catalog/wis/Atlantic/ST41001/1980/catalog.xml` seems to be faulty (fails to provide metadata with 500 exception to be thrown) at the time of testing.