### PR TITLE
F/jdbc spatial mapping

### DIFF
--- a/geoportal-commons/geoportal-commons-gpt-client/src/main/java/com/esri/geoportal/commons/gpt/client/Client.java
+++ b/geoportal-commons/geoportal-commons-gpt-client/src/main/java/com/esri/geoportal/commons/gpt/client/Client.java
@@ -246,6 +246,8 @@ public class Client implements Closeable {
           jsonRequest.put(entry.getKey(), (Integer) entry.getValue());
         } else if (entry.getValue() instanceof Boolean) {
           jsonRequest.put(entry.getKey(), (Boolean) entry.getValue());
+        } else if (entry.getValue() instanceof JsonNode) {
+          jsonRequest.set(entry.getKey(), (JsonNode) entry.getValue());
         }
       }
     }

--- a/geoportal-connectors/geoportal-harvester-jdbc/src/main/java/com/esri/geoportal/harvester/jdbc/JdbcBroker.java
+++ b/geoportal-connectors/geoportal-harvester-jdbc/src/main/java/com/esri/geoportal/harvester/jdbc/JdbcBroker.java
@@ -412,7 +412,7 @@ import org.slf4j.LoggerFactory;
               geo.put("type", "envelope");
               
               ArrayNode geometry = OBJECT_MAPPER.createArrayNode();
-              geo.set("geometry", geometry);
+              geo.set("coordinates", geometry);
               
               ArrayNode upperLeftArr = OBJECT_MAPPER.createArrayNode();
               geometry.add(upperLeftArr);

--- a/geoportal-connectors/geoportal-harvester-jdbc/src/main/java/com/esri/geoportal/harvester/jdbc/JdbcBroker.java
+++ b/geoportal-connectors/geoportal-harvester-jdbc/src/main/java/com/esri/geoportal/harvester/jdbc/JdbcBroker.java
@@ -481,16 +481,23 @@ import org.slf4j.LoggerFactory;
                 attributeName -> injectors.add((a,x,r)->{
                   if (!attributeName.name.endsWith("_xml")) {
                     if (!attributeName.array) {
-                      a.put(attributeName.name, readValue(r, columnName, String.class));
+                      String value = StringUtils.trimToEmpty(readValue(r, columnName, String.class));
+                      if (value.length() > 0) {
+                        a.put(attributeName.name, value);
+                      }
                     } else {
                       String value = StringUtils.trimToEmpty(readValue(r, columnName, String.class));
-                      String [] parts = value.split(KEYWORDS_SPLIT_REGEX);
-                      
-                      ArrayNode partsArray = OBJECT_MAPPER.createArrayNode();
-                      a.put(attributeName.name, partsArray);
-                      
-                      for (String part: parts) {
-                        partsArray.add(part);
+                      if (value.length() > 0) {
+                        String [] parts = value.split(KEYWORDS_SPLIT_REGEX);
+
+                        if (parts.length > 0) {
+                          ArrayNode partsArray = OBJECT_MAPPER.createArrayNode();
+                          a.put(attributeName.name, partsArray);
+
+                          for (String part: parts) {
+                            partsArray.add(part);
+                          }
+                        }
                       }
                     }
                   } else {

--- a/geoportal-connectors/geoportal-harvester-jdbc/src/main/java/com/esri/geoportal/harvester/jdbc/ScriptProcessor.java
+++ b/geoportal-connectors/geoportal-harvester-jdbc/src/main/java/com/esri/geoportal/harvester/jdbc/ScriptProcessor.java
@@ -64,6 +64,6 @@ import javax.script.ScriptException;
    */
   public static class Data extends HashMap<String, String> {
     public Map json;
-    public Map attr;
+    public Map<String,Object> attr;
   }
 }


### PR DESCRIPTION
This pull request allows to define spatial mapping for JDBC broker such certain fields together are considered to be coordinates constituting either an envelope or a point.

#### Examples

1. `[sw_x,sw_y,ne_x,ne_y]:envelope_geo` - square brackets denotes quadruple; these are numerical field names holding coordinates: minx, miny, maxx, maxy; envelope_geo Is a fixed name and shall not be changed,
2. `[longitude,latitude]: envelope_cen_pt` - square brackets denotes tuple; these are numerical field names holding coordinatesL longitude, latitude; envelope_cen_pt Is a fixed name and shall not be changed.