### PR TITLE
Tika size limit in hrv.properties configuration.

### DIFF
--- a/geoportal-application/geoportal-harvester-cli/src/main/java/com/esri/geoportal/cli/boot/Bootstrap.java
+++ b/geoportal-application/geoportal-harvester-cli/src/main/java/com/esri/geoportal/cli/boot/Bootstrap.java
@@ -291,10 +291,10 @@ public class Bootstrap {
               new SimpleIso15115_2MetaAnalyzer(), 
               new SimpleIso15119MetaAnalyzer());
 
-      outboundConnectorRegistry.put(AgpOutputConnector.TYPE, new AgpOutputConnector(metaAnalyzer, geometryServiceUrl));
+      outboundConnectorRegistry.put(AgpOutputConnector.TYPE, new AgpOutputConnector(metaAnalyzer, geometryServiceUrl, null));
       outboundConnectorRegistry.put(ConsoleConnector.TYPE, new ConsoleConnector());
       outboundConnectorRegistry.put(FolderConnector.TYPE, new FolderConnector());
-      outboundConnectorRegistry.put(com.esri.geoportal.harvester.gpt.GptConnector.TYPE, new com.esri.geoportal.harvester.gpt.GptConnector(geometryServiceUrl));
+      outboundConnectorRegistry.put(com.esri.geoportal.harvester.gpt.GptConnector.TYPE, new com.esri.geoportal.harvester.gpt.GptConnector(geometryServiceUrl, null));
     }
     
     return outboundConnectorRegistry;

--- a/geoportal-application/geoportal-harvester-war/src/main/resources/config/hrv-beans.xml
+++ b/geoportal-application/geoportal-harvester-war/src/main/resources/config/hrv-beans.xml
@@ -37,6 +37,7 @@
   <bean class="com.esri.geoportal.harvester.agp.AgpOutputConnector">
     <constructor-arg ref="metaAnalyzer"/>
     <constructor-arg value="${geometry.service.url}"/>
+    <constructor-arg value="${tika.sizeLimit}"/>
   </bean>
   <bean class="com.esri.geoportal.harvester.agpsrc.AgpInputConnector">
     <constructor-arg ref="metaBuilder"/>
@@ -56,6 +57,7 @@
   <bean class="com.esri.geoportal.harvester.folder.FolderConnector"/>
   <bean class="com.esri.geoportal.harvester.gpt.GptConnector">
     <constructor-arg value="${geometry.service.url}"/>
+    <constructor-arg value="${tika.sizeLimit}"/>
   </bean>
   <bean class="com.esri.geoportal.harvester.unc.UncConnector"/>
   <bean class="com.esri.geoportal.harvester.waf.WafConnector"/>

--- a/geoportal-application/geoportal-harvester-war/src/main/resources/config/hrv.properties
+++ b/geoportal-application/geoportal-harvester-war/src/main/resources/config/hrv.properties
@@ -9,3 +9,5 @@ sink.attempt.count=5
 sink.attempt.delay=1000
 
 jdbc.script.enabled=false
+
+tika.sizeLimit=-1

--- a/geoportal-commons/geoportal-commons-doc/src/main/java/com/esri/geoportal/commons/doc/DocUtils.java
+++ b/geoportal-commons/geoportal-commons-doc/src/main/java/com/esri/geoportal/commons/doc/DocUtils.java
@@ -81,7 +81,7 @@ public class DocUtils {
     }
 
     // Class Used By Geoportal Harvester
-    public static byte[] generateMetadataXML(byte[] file_bytes, String file_name) throws IOException {
+    public static byte[] generateMetadataXML(byte[] file_bytes, String file_name, Integer sizeLimit) throws IOException {
     	
     	// Input & Output Variables
     	ByteArrayInputStream base_input = new ByteArrayInputStream(file_bytes);
@@ -89,7 +89,7 @@ public class DocUtils {
     	
     	// Tika Parser Objects
         Parser               parser     = new AutoDetectParser();
-        BodyContentHandler   handler    = new BodyContentHandler();
+        BodyContentHandler   handler    = sizeLimit!=null? new BodyContentHandler(sizeLimit): new BodyContentHandler();
         Metadata             metadata   = new Metadata();
         ParseContext         context    = new ParseContext();
 	  

--- a/geoportal-connectors/geoportal-harvester-agp-publisher/src/main/java/com/esri/geoportal/harvester/agp/AgpOutputBroker.java
+++ b/geoportal-connectors/geoportal-harvester-agp-publisher/src/main/java/com/esri/geoportal/harvester/agp/AgpOutputBroker.java
@@ -96,6 +96,7 @@ import org.xml.sax.SAXException;
   private String token;
   private final Set<String> existing = new HashSet<>();
   private volatile boolean preventCleanup;
+  private final Integer sizeLimit;
 
   /**
    * Creates instance of the broker.
@@ -103,12 +104,14 @@ import org.xml.sax.SAXException;
    * @param connector connector
    * @param definition
    * @param metaAnalyzer
+   * @param sizeLimit TIKA size limit
    */
-  public AgpOutputBroker(AgpOutputConnector connector, AgpOutputBrokerDefinitionAdaptor definition, MetaAnalyzer metaAnalyzer, String geometryServiceUrl) {
+  public AgpOutputBroker(AgpOutputConnector connector, AgpOutputBrokerDefinitionAdaptor definition, MetaAnalyzer metaAnalyzer, String geometryServiceUrl, Integer sizeLimit) {
     this.connector = connector;
     this.definition = definition;
     this.metaAnalyzer = metaAnalyzer;
     this.geometryServiceUrl = geometryServiceUrl;
+    this.sizeLimit = sizeLimit;
   }
 
   @Override
@@ -133,7 +136,7 @@ import org.xml.sax.SAXException;
                   .collect(Collectors.toSet());
           if (!types.isEmpty()) {
             byte[]         rawContent = ref.getContent(types.toArray(new MimeType[types.size()]));
-            content = rawContent!=null ? DocUtils.generateMetadataXML(rawContent, new File(ref.getId()).getName()) : null;
+            content = rawContent!=null ? DocUtils.generateMetadataXML(rawContent, new File(ref.getId()).getName(), sizeLimit) : null;
           }
       }
         

--- a/geoportal-connectors/geoportal-harvester-agp-publisher/src/main/java/com/esri/geoportal/harvester/agp/AgpOutputConnector.java
+++ b/geoportal-connectors/geoportal-harvester-agp-publisher/src/main/java/com/esri/geoportal/harvester/agp/AgpOutputConnector.java
@@ -38,15 +38,18 @@ public class AgpOutputConnector implements OutputConnector<OutputBroker> {
   
   private final MetaAnalyzer metaAnalyzer;
   private final String geometryServiceUrl;
+  private final Integer sizeLimit;
 
   /**
    * Creates instance of the connector.
    * @param metaAnalyzer meta analyzer
    * @param geometryServiceUrl geometry service URL
+   * @param sizeLimit TIKA size limit
    */
-  public AgpOutputConnector(MetaAnalyzer metaAnalyzer, String geometryServiceUrl) {
+  public AgpOutputConnector(MetaAnalyzer metaAnalyzer, String geometryServiceUrl, Integer sizeLimit) {
     this.metaAnalyzer = metaAnalyzer;
     this.geometryServiceUrl = StringUtils.defaultIfBlank(geometryServiceUrl, DEFAULT_GEOMETRY_SERVICE);
+    this.sizeLimit = sizeLimit;
   }
 
   @Override
@@ -56,7 +59,7 @@ public class AgpOutputConnector implements OutputConnector<OutputBroker> {
 
   @Override
   public OutputBroker createBroker(EntityDefinition definition) throws InvalidDefinitionException {
-    return new AgpOutputBroker(this, new AgpOutputBrokerDefinitionAdaptor(definition), metaAnalyzer, geometryServiceUrl);
+    return new AgpOutputBroker(this, new AgpOutputBrokerDefinitionAdaptor(definition), metaAnalyzer, geometryServiceUrl, sizeLimit);
   }
 
   @Override

--- a/geoportal-connectors/geoportal-harvester-gpt/src/main/java/com/esri/geoportal/harvester/gpt/GptBroker.java
+++ b/geoportal-connectors/geoportal-harvester-gpt/src/main/java/com/esri/geoportal/harvester/gpt/GptBroker.java
@@ -64,6 +64,7 @@ import java.util.stream.Collectors;
   private Client client;
   private volatile boolean preventCleanup;
   private final String geometryServiceUrl;
+  private final Integer sizeLimit;
 
   private static String generateSBOM() {
     try {
@@ -81,10 +82,11 @@ import java.util.stream.Collectors;
    * @param definition definition
    * @param client client
    */
-  public GptBroker(GptConnector connector, GptBrokerDefinitionAdaptor definition, String geometryServiceUrl) {
+  public GptBroker(GptConnector connector, GptBrokerDefinitionAdaptor definition, String geometryServiceUrl, Integer sizeLimit) {
     this.connector = connector;
     this.definition = definition;
     this.geometryServiceUrl = geometryServiceUrl;
+    this.sizeLimit = sizeLimit;
   }
 
   @Override
@@ -174,7 +176,7 @@ import java.util.stream.Collectors;
                     .collect(Collectors.toSet());
             if (!types.isEmpty()) {
               byte[]         rawContent = ref.getContent(types.toArray(new MimeType[types.size()]));
-              content = rawContent!=null ? DocUtils.generateMetadataXML(rawContent, new File(ref.getId()).getName()) : null;
+              content = rawContent!=null ? DocUtils.generateMetadataXML(rawContent, new File(ref.getId()).getName(), sizeLimit) : null;
             }
         }
 

--- a/geoportal-connectors/geoportal-harvester-gpt/src/main/java/com/esri/geoportal/harvester/gpt/GptConnector.java
+++ b/geoportal-connectors/geoportal-harvester-gpt/src/main/java/com/esri/geoportal/harvester/gpt/GptConnector.java
@@ -37,13 +37,16 @@ public class GptConnector implements OutputConnector<OutputBroker> {
   private static final String DEFAULT_GEOMETRY_SERVICE = "https://utility.arcgisonline.com/ArcGIS/rest/services/Geometry/GeometryServer";
 
   private final String geometryServiceUrl;
+  private final Integer sizeLimit;
 
-  public GptConnector() {
+  public GptConnector(Integer sizeLimit) {
     this.geometryServiceUrl = DEFAULT_GEOMETRY_SERVICE;
+    this.sizeLimit = sizeLimit;
   }
 
-  public GptConnector(String geometryServiceUrl) {
+  public GptConnector(String geometryServiceUrl, Integer sizeLimit) {
     this.geometryServiceUrl = StringUtils.defaultIfBlank(geometryServiceUrl, DEFAULT_GEOMETRY_SERVICE);
+    this.sizeLimit = sizeLimit;
   }
 
   @Override
@@ -83,7 +86,7 @@ public class GptConnector implements OutputConnector<OutputBroker> {
 
   @Override
   public OutputBroker createBroker(EntityDefinition definition) throws InvalidDefinitionException {
-    return new GptBroker(this, new GptBrokerDefinitionAdaptor(definition), geometryServiceUrl);
+    return new GptBroker(this, new GptBrokerDefinitionAdaptor(definition), geometryServiceUrl, sizeLimit);
   }
   
 }


### PR DESCRIPTION
Tika maximum size is configurable through hrv.properties:
`tika.sizeLimit=<size limit>`

where:

&lt;size limit&gt;:

- positive number - maximum file size in bytes
- -1 - no size limit
- empty - default size limit (100k bytes)