### PR TITLE
F/check for binary file descr

### DIFF
--- a/geoportal-connectors/geoportal-harvester-unc/src/main/java/com/esri/geoportal/harvester/unc/UncFile.java
+++ b/geoportal-connectors/geoportal-harvester-unc/src/main/java/com/esri/geoportal/harvester/unc/UncFile.java
@@ -24,6 +24,7 @@ import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Date;
+import java.util.Objects;
 import org.apache.commons.io.IOUtils;
 
 /**
@@ -31,7 +32,7 @@ import org.apache.commons.io.IOUtils;
  */
 /*package*/ class UncFile {
   private final UncBroker broker;
-  private final Path file;
+  public final Path file;
 
   /**
    * Creates instance of UNC file.
@@ -86,4 +87,5 @@ import org.apache.commons.io.IOUtils;
   public String toString() {
     return file.toString();
   }
+
 }

--- a/geoportal-connectors/geoportal-harvester-unc/src/main/java/com/esri/geoportal/harvester/unc/UncFile.java
+++ b/geoportal-connectors/geoportal-harvester-unc/src/main/java/com/esri/geoportal/harvester/unc/UncFile.java
@@ -24,7 +24,6 @@ import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Date;
-import java.util.Objects;
 import org.apache.commons.io.IOUtils;
 
 /**

--- a/geoportal-connectors/geoportal-harvester-waf/src/main/java/com/esri/geoportal/harvester/waf/WafFile.java
+++ b/geoportal-connectors/geoportal-harvester-waf/src/main/java/com/esri/geoportal/harvester/waf/WafFile.java
@@ -46,7 +46,7 @@ import org.apache.http.impl.client.CloseableHttpClient;
 /*package*/ class WafFile {
 
   private final WafBroker broker;
-  private final URL fileUrl;
+  public  final URL fileUrl;
   private final SimpleCredentials creds;
 
   /**


### PR DESCRIPTION
# Check for binary file xml descriptor

When harvesting WAF or UNC folders for binary files like images, PDF's, Microsoft World documents, this new functionality will cause harvester to pick existing metadata file over the corresponding binary file. Association between binary file and and the metadata is by naming convention, for example if the main (binary) file is some_image.jpg then harvester will consider some_image.jpg.xml as a metadata file and will take than one and skip some_image.jpg. If such metadata file is absent, then harvester will process some_image.jpg in an old way, i.e. through Apache Tika library.