### PR TITLE
Harvesting with Json

### DIFF
--- a/geoportal-commons/geoportal-commons-gpt-client/src/main/java/com/esri/geoportal/commons/gpt/client/Client.java
+++ b/geoportal-commons/geoportal-commons-gpt-client/src/main/java/com/esri/geoportal/commons/gpt/client/Client.java
@@ -159,11 +159,11 @@ public class Client implements Closeable {
               envelope_geo.put("type", "envelope");
               ArrayNode coordinates = mapper.createArrayNode();
               ArrayNode southWest = coordinates.addArray();
-              southWest.add(xmin);
-              southWest.add(ymin);
+              southWest.add(Math.max(xmin, -180.0));
+              southWest.add(Math.min(ymax, 90.0));
               ArrayNode northEast = coordinates.addArray();
-              northEast.add(xmax);
-              northEast.add(ymax);
+              northEast.add(Math.min(xmax, 180.0));
+              northEast.add(Math.max(ymin, -90.0));
               envelope_geo.set("coordinates", coordinates);
 
               jsonRequest.set("envelope_geo", envelope_geo);


### PR DESCRIPTION
## Harvesting with Json
This pull request addresses issue with invalid coordinates being published if publishing through Json.
### Testing
1. Establish harvesting task to harvest from ArcGIS server into Geoportal Server,
2. Use [http://inspire1081:6080/arcgis](http://inspire1081:6080/arcgis) as input ArcGIS server,
3. Enable 'Emit JSON' on the input broker definition,
4. Enable 'Accept JSON' on the output broker definition,
5. Check harvester history; no records should fail harvesting,
6. Check content of the Geoportal Server; number of records shown for the task should agree with number of records acquired from the ArcGIS server.
### Further recommendations
1. Test with other json-emitting input brokers:
    - CKAN, 
    - DATA.GOV, 
    - DCAT,
    - Geoportal Server,
    - Portal for ArcGIS,
    - THREDDS
 2. Look for discrepancies.