### PR TITLE
Harvesting tags into keywords from ArcGIS Portal (ArcGIS Online).

### DIFF
--- a/geoportal-connectors/geoportal-harvester-agp-source/src/main/java/com/esri/geoportal/harvester/agpsrc/AgpInputBroker.java
+++ b/geoportal-connectors/geoportal-harvester-agp-source/src/main/java/com/esri/geoportal/harvester/agpsrc/AgpInputBroker.java
@@ -62,6 +62,7 @@ import org.apache.http.impl.client.HttpClientBuilder;
 import com.esri.geoportal.commons.utils.XmlUtils;
 import com.esri.geoportal.harvester.api.DataContent;
 import com.esri.geoportal.harvester.api.defs.TaskDefinition;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 
 /**
  * ArcGIS Portal output broker.
@@ -243,6 +244,14 @@ import com.esri.geoportal.harvester.api.defs.TaskDefinition;
     }
     if (definition.getEmitJson()) {
       ref.addContext(MimeType.APPLICATION_JSON, mapper.writeValueAsString(itemEntry).getBytes("UTF-8"));
+      
+      // attributes
+
+      if (itemEntry.tags!=null) {
+        ArrayNode tagsNode = mapper.createArrayNode();
+        Arrays.stream(itemEntry.tags).forEach(tag -> tagsNode.add(tag));
+        ref.getAttributesMap().put("keywords_s", tagsNode);
+      }
     }
 
     return ref;


### PR DESCRIPTION
## This pull request provides additional enhancements to harvesting ArcGIS Portal (ArcGIS Online) into Geoportal Server.
### Description
Item info (if present) provides additional source for information when creating records within Geoportal Server:

1. item info "tags" => keywords_s,

### Notes
This additional data fetching works only if input broker has "Emit JSON" checked and the output broker has "Accept JSON" checked. Generated Dublin Core metadata will not have tags/keywords nor accessInformation stored.