### PR TITLE
Switch current pane to "Home" after user starts a process.

### DIFF
--- a/geoportal-application/geoportal-harvester-war/src/main/webapp/hrv/ui/tasks/Tasks.js
+++ b/geoportal-application/geoportal-harvester-war/src/main/webapp/hrv/ui/tasks/Tasks.js
@@ -190,7 +190,7 @@ define(["dojo/_base/declare",
         var data = evt.data;
         TasksREST.execute(data.uuid,data.taskDefinition.ignoreRobotsTxt, data.taskDefinition.incremental).then(
           lang.hitch(this,function(){
-            this.load(this.groupByCheckBox.get('checked'));
+            router.go("/home");
           }),
           lang.hitch(this,function(error){
             console.error(error);


### PR DESCRIPTION
## Description
After task has been successfully selected to run, application switches automatically to "Home" panel view.
No switching happens if there is an error in submitting task to run.