### PR TITLE
Potential fix for code scanning alert no. 30: XSLT transformation with user-controlled stylesheet

### DIFF
--- a/geoportal-commons/geoportal-commons-meta/src/main/java/com/esri/geoportal/commons/meta/xml/BaseXmlMetaBuilder.java
+++ b/geoportal-commons/geoportal-commons-meta/src/main/java/com/esri/geoportal/commons/meta/xml/BaseXmlMetaBuilder.java
@@ -22,6 +22,8 @@ import com.esri.geoportal.commons.meta.MapAttribute;
 import static com.esri.geoportal.commons.meta.xml.TransformerLoader.loadTransformer;
 import java.io.IOException;
 import java.util.Properties;
+import javax.xml.XMLConstants;
+import javax.xml.transform.TransformerFactory;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.Result;
@@ -47,7 +49,9 @@ public abstract class BaseXmlMetaBuilder implements MetaBuilder {
    * @throws javax.xml.transform.TransformerConfigurationException if error compiling xslt
    */
   public BaseXmlMetaBuilder(String encoderXslt) throws IOException, TransformerConfigurationException {
-    xsltEncodeDC = loadTransformer(encoderXslt);
+    TransformerFactory factory = TransformerFactory.newInstance();
+    factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+    xsltEncodeDC = factory.newTemplates(new javax.xml.transform.stream.StreamSource(encoderXslt));
   }
 
   @Override


### PR DESCRIPTION
Potential fix for [https://github.com/Esri/geoportal-server-harvester/security/code-scanning/30](https://github.com/Esri/geoportal-server-harvester/security/code-scanning/30)

To fix the problem, we need to ensure that the XSLT transformation is performed with secure processing enabled. This is done by setting the `XMLConstants.FEATURE_SECURE_PROCESSING` feature to `true` on the `TransformerFactory` before compiling/loading the XSLT stylesheet. The best way to do this is to update the `loadTransformer` method (which is called in the constructor of `BaseXmlMetaBuilder`) to always enable secure processing mode on the `TransformerFactory` before creating the `Templates` object. Since we only have access to the code in `BaseXmlMetaBuilder.java`, and the import for `loadTransformer` is shown, we should add the secure processing feature in the constructor before calling `loadTransformer`, or (preferably) update the `loadTransformer` method itself if it is shown in the code. If not, we can wrap the call with a secure factory in the constructor.

If we cannot edit `loadTransformer`, we can create a secure `TransformerFactory` in the constructor and use it to compile the XSLT. This requires importing `javax.xml.XMLConstants` and using `TransformerFactory.setFeature`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
