### PR TITLE
resolve issue-254

### DIFF
--- a/geoportal-commons/geoportal-commons-ags-client/src/main/java/com/esri/geoportal/commons/ags/client/AgsClient.java
+++ b/geoportal-commons/geoportal-commons-ags-client/src/main/java/com/esri/geoportal/commons/ags/client/AgsClient.java
@@ -268,7 +268,7 @@ public class AgsClient implements Closeable {
           List<Double> flatExtent = new ArrayList<>();
           for (Double[] row : source.extent) {
               if (row != null) {
-                boolean addAll = flatExtent.addAll(Arrays.asList(row));
+                flatExtent.addAll(Arrays.asList(row));
               }
           }
           target.extent = flatExtent.toArray(Double[]::new);

--- a/geoportal-commons/geoportal-commons-ags-client/src/main/java/com/esri/geoportal/commons/ags/client/AgsClient.java
+++ b/geoportal-commons/geoportal-commons-ags-client/src/main/java/com/esri/geoportal/commons/ags/client/AgsClient.java
@@ -19,6 +19,7 @@ import com.esri.geoportal.commons.utils.SimpleCredentials;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonParser.Feature;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.Closeable;
@@ -230,7 +231,7 @@ public class AgsClient implements Closeable {
       try {
         // try reading with extent as 1D array      
         response = mapper.readValue(responseContent, ItemInfo.class);      
-      } catch (Exception ex) {
+      } catch (JsonProcessingException ex) {
         ItemInfo2D response2D = mapper.readValue(responseContent, ItemInfo2D.class);
         response = convertItemInfo2Dto1D(response2D);        
       }

--- a/geoportal-commons/geoportal-commons-ags-client/src/main/java/com/esri/geoportal/commons/ags/client/AgsClient.java
+++ b/geoportal-commons/geoportal-commons-ags-client/src/main/java/com/esri/geoportal/commons/ags/client/AgsClient.java
@@ -28,7 +28,11 @@ import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.stream.Collectors;
 import org.apache.commons.codec.net.URLCodec;
 import org.apache.commons.io.IOUtils;
@@ -221,11 +225,58 @@ public class AgsClient implements Closeable {
       mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
       mapper.configure(Feature.ALLOW_NON_NUMERIC_NUMBERS, true);
       mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
-      ItemInfo response = mapper.readValue(responseContent, ItemInfo.class);
+      
+      ItemInfo response;
+      try {
+        // try reading with extent as 1D array      
+        response = mapper.readValue(responseContent, ItemInfo.class);      
+      } catch (Exception ex) {
+        ItemInfo2D response2D = mapper.readValue(responseContent, ItemInfo2D.class);
+        response = convertItemInfo2Dto1D(response2D);        
+      }
                       
       return response;
     }
   }
+  
+
+  public static ItemInfo convertItemInfo2Dto1D(ItemInfo2D source) {
+      ItemInfo target = new ItemInfo();
+
+      // Copy all simple fields
+      target.culture = source.culture;
+      target.name = source.name;
+      target.guid = source.guid;
+      target.catalogPath = source.catalogPath;
+      target.snippet = source.snippet;
+      target.description = source.description;
+      target.summary = source.summary;
+      target.title = source.title;
+      target.tags = source.tags;
+      target.type = source.type;
+      target.typeKeywords = source.typeKeywords;
+      target.thumbnail = source.thumbnail;
+      target.url = source.url;
+      target.spatialReference = source.spatialReference;
+      target.accessInformation = source.accessInformation;
+      target.licenseInfo = source.licenseInfo;
+      target.hasMetadata = source.hasMetadata;
+      target.metadataXML = source.metadataXML;
+
+      // Flatten extent from Double[][] to Double[]
+      if (source.extent != null) {
+          List<Double> flatExtent = new ArrayList<>();
+          for (Double[] row : source.extent) {
+              if (row != null) {
+                boolean addAll = flatExtent.addAll(Arrays.asList(row));
+              }
+          }
+          target.extent = flatExtent.toArray(Double[]::new);
+      }
+
+      return target;
+    }
+  
   
   /**
    * Reads layer information.
@@ -243,7 +294,11 @@ public class AgsClient implements Closeable {
     if (!isValidFolderName(folder)) {
       throw new IllegalArgumentException("Invalid folder name: " + folder);
     }
-    String url = rootUrl.toURI().resolve("rest/services/").resolve(StringUtils.stripToEmpty(folder)).resolve(si.name + "/" + si.type + "/" + lRef.id).toASCIIString();
+    // for some cases service name includes the foldername
+    if (si.name.startsWith(folder + "/")) {
+      si.name = si.name.replace(folder + "/", "");
+    }
+    String url = rootUrl.toURI().resolve("rest/services/").resolve(StringUtils.stripToEmpty(folder)).resolve(URLEncoder.encode(si.name, StandardCharsets.UTF_8.toString()) + "/" + si.type + "/" + lRef.id).toASCIIString();
     
    // SSRF mitigation: ensure the constructed URL is within the rootUrl
     if (!isUrlWithinRoot(url)) {

--- a/geoportal-commons/geoportal-commons-ags-client/src/main/java/com/esri/geoportal/commons/ags/client/ItemInfo2D.java
+++ b/geoportal-commons/geoportal-commons-ags-client/src/main/java/com/esri/geoportal/commons/ags/client/ItemInfo2D.java
@@ -18,7 +18,7 @@ package com.esri.geoportal.commons.ags.client;
 /**
  * Item Info.
  */
-public final class ItemInfo {
+public final class ItemInfo2D {
   public String culture;
   public String name;
   public String guid;
@@ -32,7 +32,7 @@ public final class ItemInfo {
   public String [] typeKeywords;
   public String thumbnail;
   public String url;
-  public Double [] extent;
+  public Double [][] extent;
   public String spatialReference;
   public String accessInformation;
   public String licenseInfo;

--- a/geoportal-connectors/geoportal-harvester-folder/src/main/java/com/esri/geoportal/harvester/folder/FolderBroker.java
+++ b/geoportal-connectors/geoportal-harvester-folder/src/main/java/com/esri/geoportal/harvester/folder/FolderBroker.java
@@ -138,7 +138,9 @@ import org.slf4j.LoggerFactory;
               //When source is geoportal and item does not have title: URI conatins access_token, remove access_token from title
               {
                   int index = title.indexOf("_access_token");
-                  title = title.substring(0,index);
+                  if (index > -1) {
+                    title = title.substring(0,index);
+                  }
               }
           }
           Path f = generateFileName(ref.getBrokerUri(), ref.getSourceUri(), title, extension);
@@ -197,7 +199,7 @@ import org.slf4j.LoggerFactory;
         subFolder.remove(0);
       }     
       for (String sf : subFolder) {
-        fileName = Paths.get(fileName.toString(), (id.isBlank() ? sf :id));
+        fileName = Paths.get(fileName.toString(), (!sf.isBlank() ? sf :id));
       }
       if (!fileName.getFileName().toString().endsWith(extension)) {
         fileName = fileName.getParent().resolve(fileName.getFileName() + "." + extension);


### PR DESCRIPTION
there are at least 2 different ways the service extent may show up in ArcGIS REST services. Harvester did not account for this.

a 1D array of 4 values:

```
 "extent" : [-170.346666666667, 13.36896, 144.65031, 64.5007245697712  ]
```

or a 2D array consisting of the 2 corners as 2D arrays each:

```
"extent": [
  [
   3.97968027461749,
   51.9334152055809
  ],
  [
   4.09706150216137,
   51.9845415200289
  ]
 ]
```
